### PR TITLE
Added support for reading support resolutions from the WIM system

### DIFF
--- a/SeventhHeavenUI/Classes/PrimaryScreen.cs
+++ b/SeventhHeavenUI/Classes/PrimaryScreen.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeventhHeaven.Classes
+{
+    public class PrimaryScreen
+    {
+
+        public static List<SupportedResolution> GetSupportedResolutions()
+        {
+            var scope = new System.Management.ManagementScope();
+            var q = new System.Management.ObjectQuery("SELECT * FROM CIM_VideoControllerResolution");
+
+            UInt32 maxHResolution;
+            UInt32 maxVResolution;
+
+            using (var searcher = new System.Management.ManagementObjectSearcher(scope, q))
+            {
+                var results = searcher.Get();
+
+                foreach (var item in results)
+                {
+                    maxHResolution = (UInt32)item["HorizontalResolution"];
+                    maxVResolution = (UInt32)item["VerticalResolution"];
+                    SupportedResolution.CreateIfNotExist(maxHResolution, maxVResolution);
+                }
+            }
+
+            return SupportedResolution.GetAllCachedResolutions();
+        }
+    }
+}

--- a/SeventhHeavenUI/Classes/SupportedResolution.cs
+++ b/SeventhHeavenUI/Classes/SupportedResolution.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeventhHeaven.Classes
+{
+    public class SupportedResolution
+    {
+        public UInt32 H { get; private set; }
+        public UInt32 V { get; private set; }
+
+        private SupportedResolution(UInt32 h, UInt32 v)
+        {
+            H = h;
+            V = v;
+        }
+
+        private static Dictionary<string, SupportedResolution> cache = new Dictionary<string, SupportedResolution>();
+
+        public static SupportedResolution CreateIfNotExist(UInt32 h, UInt32 v)
+        {
+            string key = $"{h}x{v}";
+            if (!cache.ContainsKey(key))
+            {
+                cache[key] = new SupportedResolution(h, v);
+            }
+            return cache[key];
+        }
+
+        public static List<SupportedResolution> GetAllCachedResolutions()
+        {
+            return cache.Values.ToList();
+        }
+    }
+}

--- a/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
+++ b/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
@@ -42,66 +42,6 @@
         <Text>Auto</Text>
         <Settings>window_size_x = 0,window_size_y = 0</Settings>
       </Option>
-      <Option>
-        <Text>640x480</Text>
-        <Settings>window_size_x = 640,window_size_y = 480</Settings>
-      </Option>
-      <Option>
-        <Text>800x600</Text>
-        <Settings>window_size_x = 800,window_size_y = 600</Settings>
-      </Option>
-      <Option>
-        <Text>1024x768</Text>
-        <Settings>window_size_x = 1024,window_size_y = 768</Settings>
-      </Option>
-      <Option>
-        <Text>1280x720</Text>
-        <Settings>window_size_x = 1280,window_size_y = 720</Settings>
-      </Option>
-      <Option>
-        <Text>1280x960</Text>
-        <Settings>window_size_x = 1280,window_size_y = 960</Settings>
-      </Option>
-      <Option>
-        <Text>1400x1050</Text>
-        <Settings>window_size_x = 1400,window_size_y = 1050</Settings>
-      </Option>
-      <Option>
-        <Text>1440x1080</Text>
-        <Settings>window_size_x = 1440,window_size_y = 1080</Settings>
-      </Option>
-      <Option>
-        <Text>1600x1200</Text>
-        <Settings>window_size_x = 1600,window_size_y = 1200</Settings>
-      </Option>
-      <Option>
-        <Text>1920x1080</Text>
-        <Settings>window_size_x = 1920,window_size_y = 1080</Settings>
-      </Option>
-      <Option>
-        <Text>1920x1440</Text>
-        <Settings>window_size_x = 1920,window_size_y = 1440</Settings>
-      </Option>
-      <Option>
-        <Text>2048x1536</Text>
-        <Settings>window_size_x = 2048,window_size_y = 1536</Settings>
-      </Option>
-      <Option>
-        <Text>2560x1440</Text>
-        <Settings>window_size_x = 2560,window_size_y = 1440</Settings>
-      </Option>
-      <Option>
-        <Text>2560x1920</Text>
-        <Settings>window_size_x = 2560,window_size_y = 1920</Settings>
-      </Option>
-      <Option>
-        <Text>2880x2160</Text>
-        <Settings>window_size_x = 2880,window_size_y = 2160</Settings>
-      </Option>
-      <Option>
-        <Text>3840x2160</Text>
-        <Settings>window_size_x = 3840,window_size_y = 2160</Settings>
-      </Option>
     </Setting>
 
   <Setting xsi:type="DropDown">

--- a/SeventhHeavenUI/SeventhHeavenUI.csproj
+++ b/SeventhHeavenUI/SeventhHeavenUI.csproj
@@ -141,8 +141,10 @@
     <Compile Include="Classes\GameLauncher.cs" />
     <Compile Include="Classes\KeyboardInputSender.cs" />
     <Compile Include="Classes\OpenFolderDialog.cs" />
+    <Compile Include="Classes\PrimaryScreen.cs" />
     <Compile Include="Classes\ReloadListOption.cs" />
     <Compile Include="Classes\ResourceHelper.cs" />
+    <Compile Include="Classes\SupportedResolution.cs" />
     <Compile Include="Classes\Themes\Classic7HTheme.cs" />
     <Compile Include="Classes\Themes\DarkThemeWithBackground.cs" />
     <Compile Include="Classes\Themes\LightThemeWithBackground.cs" />

--- a/SeventhHeavenUI/Windows/ConfigureGLWindow.xaml.cs
+++ b/SeventhHeavenUI/Windows/ConfigureGLWindow.xaml.cs
@@ -56,6 +56,21 @@ namespace SeventhHeaven.Windows
                 return false;
             }
 
+            // build new DDOption for resolutions
+            List<Iros._7th.Workshop.ConfigSettings.DDOption> DigitalResolutions = new List<Iros._7th.Workshop.ConfigSettings.DDOption>();
+            DigitalResolutions.Add(new Iros._7th.Workshop.ConfigSettings.DDOption() { Settings = "window_size_x = 0,window_size_y = 0", Text = "Auto" });
+
+            List<SupportedResolution> supportedResolutions = PrimaryScreen.GetSupportedResolutions();
+            foreach(SupportedResolution sr in supportedResolutions)
+            {
+                DigitalResolutions.Add(new Iros._7th.Workshop.ConfigSettings.DDOption() { Settings = $"window_size_x = {sr.H},window_size_y = {sr.V}", Text = $"{sr.H}x{sr.V}"});
+            }
+
+            // find the resolutions option
+            Iros._7th.Workshop.ConfigSettings.DropDown ResolutionDD = (Iros._7th.Workshop.ConfigSettings.DropDown)_spec.Settings.Find(itm => { return itm.Name == "Resolution"; });
+            // over ride it with OS reported suported resolutions
+            ResolutionDD.Options = DigitalResolutions;
+
             _settings = new Iros._7th.Workshop.ConfigSettings.Settings(_file);
             _settings.SetMissingDefaults(_spec.Settings);
 

--- a/SeventhHeavenUI/Windows/ConfigureGLWindow.xaml.cs
+++ b/SeventhHeavenUI/Windows/ConfigureGLWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace SeventhHeaven.Windows
             }
 
             // find the resolutions option
-            Iros._7th.Workshop.ConfigSettings.DropDown ResolutionDD = (Iros._7th.Workshop.ConfigSettings.DropDown)_spec.Settings.Find(itm => { return itm.Name == "Resolution"; });
+            Iros._7th.Workshop.ConfigSettings.DropDown ResolutionDD = (Iros._7th.Workshop.ConfigSettings.DropDown)_spec.Settings.Find(item => { return item.Name == "Resolution"; });
             // over ride it with OS reported suported resolutions
             ResolutionDD.Options = DigitalResolutions;
 


### PR DESCRIPTION
Update so that the config file only holds the info for the options for dropdown not that values, the values are now pulled from the WIM system in windows by querying for the CIM_VideoControllerResolution, as we don't support refresh rates this has been removed and a singleton system put in place to prevent duplicate resolutions because of refresh rates

This is to implement feature request #5 