### PR TITLE
Bugfix/hexd ordering

### DIFF
--- a/7thWrapperLib/Wrap.cs
+++ b/7thWrapperLib/Wrap.cs
@@ -359,20 +359,21 @@ namespace _7thWrapperLib {
                     DebugLogger.WriteLine($"Loading library DLL {LL}");
                     LoadLibrary(LL);
                 }
+                profile.Mods.Reverse();
                 foreach (var mod in profile.Mods) {
-                    foreach (string LA in mod.GetLoadAssemblies()) {
+                    foreach (string LA in mod.GetLoadAssemblies())
+                    {
                         DebugLogger.WriteLine($"Loading assembly DLL {LA}");
                         var asm = System.Reflection.Assembly.LoadFrom(LA);
-                        try {
+                        try
+                        {
                             string path = mod.BaseFolder;
                             asm.GetType("_7thHeaven.Main")
                                 .GetMethod("Init", new[] { typeof(RuntimeMod) })
                                 .Invoke(null, new object[] { mod });
-                        } catch { }
+                        }
+                        catch { }
                     }
-                }
-
-                foreach (var mod in profile.Mods) {
                     foreach (string file in mod.GetPathOverrideNames("hext")) {
                         foreach (var of in mod.GetOverrides("hext\\" + file)) {
                             System.IO.Stream s;

--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -753,8 +753,11 @@ namespace SeventhHeaven.Classes
                         if (Sys.Settings.GameLaunchSettings.AutoUnmountGameDisc && Instance.DidMountVirtualDisc)
                         {
                             Instance.RaiseProgressChanged(ResourceHelper.Get(StringKey.AutoUnmountingGameDisc));
-                            Instance.DiscMounter.UnmountVirtualGameDisc();
-                            Instance.DiscMounter = null;
+                            if (Instance.DiscMounter != null)
+                            {
+                                Instance.DiscMounter.UnmountVirtualGameDisc();
+                                Instance.DiscMounter = null;
+                            }
                         }
 
                         // ensure Reunion is re-enabled when ff7 process exits in case it failed above for any reason


### PR DESCRIPTION
Bug where Textures order were the opposite to the hext and DLL load order, this has been fixed so it's now consistent across of them,

Also fixed a bug that was caused if 7th heaven could not mount when it exits it's tries to unmount using a null pointer this has been wrapped in a check to make sure that the pointer is not null.