### PR TITLE
7th: Add support for FFNxConfig inside the mod.xml file

### DIFF
--- a/7thHeaven.Code/FFNxConfigManager.cs
+++ b/7thHeaven.Code/FFNxConfigManager.cs
@@ -225,6 +225,8 @@ namespace Iros._7th.Workshop.ConfigSettings
 
         public void Backup()
         {
+            if (File.Exists(_pathToFFNxTomlBak)) File.Delete(_pathToFFNxTomlBak);
+
             File.Copy(_pathToFFNxToml, _pathToFFNxTomlBak);
         }
 
@@ -232,7 +234,8 @@ namespace Iros._7th.Workshop.ConfigSettings
         {
             if (File.Exists(_pathToFFNxTomlBak))
             {
-                File.Copy(_pathToFFNxTomlBak, _pathToFFNxToml);
+                File.Delete(_pathToFFNxToml);
+                File.Move(_pathToFFNxTomlBak, _pathToFFNxToml);
                 Reload();
             }
         }

--- a/7thWrapperLib/Profile.cs
+++ b/7thWrapperLib/Profile.cs
@@ -155,6 +155,7 @@ namespace _7thWrapperLib
         public List<string> LoadAssemblies { get; private set; }
         public List<string> LoadPlugins { get; private set; }
         public List<ProgramInfo> LoadPrograms { get; private set; }
+        public Dictionary<string, string> FFNxConfig { get; private set; }
 
         [NonSerialized]
         public Wpf32Window WpfWindowInterop;
@@ -175,6 +176,7 @@ namespace _7thWrapperLib
             LoadAssemblies = modInfo.LoadAssemblies.ToList();
             LoadPlugins = modInfo.LoadPlugins.ToList();
             LoadPrograms = modInfo.LoadPrograms.ToList();
+            FFNxConfig = modInfo.FFNxConfig;
         }
 
         private void ScanChunk()
@@ -872,6 +874,7 @@ namespace _7thWrapperLib
             LoadAssemblies = new List<string>();
             LoadPlugins = new List<string>();
             LoadPrograms = new List<ProgramInfo>();
+            FFNxConfig = new Dictionary<string, string>();
 
             Guid.TryParse(doc.SelectSingleNode("/ModInfo/ID").NodeText(), out Guid parsedId);
             ID = parsedId;
@@ -906,6 +909,11 @@ namespace _7thWrapperLib
                 LoadAssemblies.Add(LA.InnerText);
             foreach (XmlNode LP in doc.SelectNodes("/ModInfo/LoadPlugin"))
                 LoadPlugins.Add(LP.InnerText);
+            foreach (XmlNode xmlNode in doc.SelectNodes("/ModInfo/FFNxConfig"))
+            {
+                foreach(XmlNode child in xmlNode)
+                    FFNxConfig.Add(child.Name, child.InnerText);
+            }
 
             XmlNode loadPrograms = doc.SelectSingleNode("/ModInfo/LoadPrograms");
 
@@ -967,6 +975,7 @@ namespace _7thWrapperLib
             OrderAfter = new List<Guid>();
             OrderBefore = new List<Guid>();
             Compatibility = null;
+            FFNxConfig = new Dictionary<string, string>();
         }
 
         public Guid ID { get; set; }
@@ -995,6 +1004,7 @@ namespace _7thWrapperLib
         public Compatibility Compatibility { get; set; }
         public List<Guid> OrderBefore { get; set; }
         public List<Guid> OrderAfter { get; set; }
+        public Dictionary<string, string> FFNxConfig { get; set; }
 
     }
 

--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -478,6 +478,20 @@ namespace SeventhHeaven.Classes
                 //
                 Instance.RaiseProgressChanged(ResourceHelper.Get(StringKey.CopyingEasyHookToFf7PathIfNotFoundOrOlder));
                 CopyEasyHookDlls();
+
+                //
+                // Inherit FFNx Config keys from each mod
+                //
+                Sys.FFNxConfig.Backup();
+                foreach(var mod in runtimeProfile.Mods)
+                {
+                    foreach(var config in mod.FFNxConfig)
+                    {
+                        if (Sys.FFNxConfig.HasKey(config.Key))
+                            Sys.FFNxConfig.Set(config.Key, config.Value);
+                    }
+                }
+                Sys.FFNxConfig.Save();
             }
 
             //
@@ -770,6 +784,8 @@ namespace SeventhHeaven.Classes
                         Logger.Error(ex);
                     }
 
+                    // Restore FFNx config after the game is closed
+                    Sys.FFNxConfig.RestoreBackup();
                 };
 
                 int secondsToWait = 120;


### PR DESCRIPTION
Fix also minor bug happening while backupping/restoring the FFNx.toml file through the FFNxConfigManager class.

An example of mod using this new node:
```xml
<?xml version="1.0"?>
<ModInfo>
  <Author>Julian Xhokaxhiu</Author>
  <Version>0.1</Version>
  <Description>FFNx Config override example</Description>
  <Link>https://github.com/julianxhokaxhiu/FFNx</Link>
  <FFNxConfig>
    <ff7_footsteps>true</ff7_footsteps>
  </FFNxConfig>
</ModInfo>
```

The behavior is documented as following when you launch the game:
-> It will backup your current `FFNx.toml`
-> The code will loop through every mod you have enabled ( top to bottom ) and will apply every new config found in each `mod.xml` if any
-> It will run the game as usual
-> When the game is closed it will restore the previously backupped `FFNx.toml` file

This should guarantee a "temporal" apply of the config through mods which might change on each run. The restore logic should also work in case the game crashes, so we should be safe in most cases. Didn't though of any other edge case yet.