### PR TITLE
7th: Customize FFNx Flag setting behavior

### DIFF
--- a/7thWrapperLib/Profile.cs
+++ b/7thWrapperLib/Profile.cs
@@ -155,7 +155,7 @@ namespace _7thWrapperLib
         public List<string> LoadAssemblies { get; private set; }
         public List<string> LoadPlugins { get; private set; }
         public List<ProgramInfo> LoadPrograms { get; private set; }
-        public Dictionary<string, string> FFNxConfig { get; private set; }
+        public List<FFNxFlag> FFNxConfig { get; private set; }
 
         [NonSerialized]
         public Wpf32Window WpfWindowInterop;
@@ -874,7 +874,7 @@ namespace _7thWrapperLib
             LoadAssemblies = new List<string>();
             LoadPlugins = new List<string>();
             LoadPrograms = new List<ProgramInfo>();
-            FFNxConfig = new Dictionary<string, string>();
+            FFNxConfig = new List<FFNxFlag>();
 
             Guid.TryParse(doc.SelectSingleNode("/ModInfo/ID").NodeText(), out Guid parsedId);
             ID = parsedId;
@@ -912,7 +912,18 @@ namespace _7thWrapperLib
             foreach (XmlNode xmlNode in doc.SelectNodes("/ModInfo/FFNxConfig"))
             {
                 foreach(XmlNode child in xmlNode)
-                    FFNxConfig.Add(child.Name, child.InnerText);
+                {
+                    var flag = new FFNxFlag();
+
+                    flag.Key = child.Name;
+                    flag.Value = child.InnerText;
+
+                    foreach (XmlAttribute attr in child.Attributes)
+                        flag.Attributes.Add(attr.Name, int.Parse(attr.Value));
+
+                    FFNxConfig.Add(flag);
+                }
+                    
             }
 
             XmlNode loadPrograms = doc.SelectSingleNode("/ModInfo/LoadPrograms");
@@ -975,7 +986,7 @@ namespace _7thWrapperLib
             OrderAfter = new List<Guid>();
             OrderBefore = new List<Guid>();
             Compatibility = null;
-            FFNxConfig = new Dictionary<string, string>();
+            FFNxConfig = new List<FFNxFlag>();
         }
 
         public Guid ID { get; set; }
@@ -1004,7 +1015,7 @@ namespace _7thWrapperLib
         public Compatibility Compatibility { get; set; }
         public List<Guid> OrderBefore { get; set; }
         public List<Guid> OrderAfter { get; set; }
-        public Dictionary<string, string> FFNxConfig { get; set; }
+        public List<FFNxFlag> FFNxConfig { get; set; }
 
     }
 
@@ -1283,6 +1294,21 @@ namespace _7thWrapperLib
         public override bool IsActive()
         {
             return !_child.IsActive();
+        }
+    }
+
+    [Serializable]
+    public class FFNxFlag
+    {
+        public string Key;
+        public string Value;
+        public Dictionary<string, int> Attributes;
+
+        public FFNxFlag()
+        {
+            Key = String.Empty;
+            Value = String.Empty;
+            Attributes = new Dictionary<string, int>();
         }
     }
 }

--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -483,12 +483,30 @@ namespace SeventhHeaven.Classes
                 // Inherit FFNx Config keys from each mod
                 //
                 Sys.FFNxConfig.Backup();
-                foreach(var mod in runtimeProfile.Mods)
+                foreach (RuntimeMod mod in runtimeProfile.Mods)
                 {
-                    foreach(var config in mod.FFNxConfig)
+                    foreach(FFNxFlag flag in mod.FFNxConfig)
                     {
-                        if (Sys.FFNxConfig.HasKey(config.Key))
-                            Sys.FFNxConfig.Set(config.Key, config.Value);
+                        bool addConfig = true;
+
+                        if (flag.Attributes.Count > 0)
+                        {
+                            foreach (var attr in flag.Attributes)
+                            {                                
+                                foreach(Iros._7th.Workshop.ProfileItem item in Sys.ActiveProfile.ActiveItems)
+                                {
+                                    foreach(ProfileSetting setting in item.Settings)
+                                    {
+                                        if (setting.ID == attr.Key && setting.Value != attr.Value) addConfig = false;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (addConfig)
+                        {
+                            if (Sys.FFNxConfig.HasKey(flag.Key)) Sys.FFNxConfig.Set(flag.Key, flag.Value);
+                        }
                     }
                 }
                 Sys.FFNxConfig.Save();


### PR DESCRIPTION
This PR is a follow up of #29 and introduces the behavior we discussed the last time, allowing modders to decide when to enable a specific flag in FFNx, based on what the user configured inside of their own mod panel.

Through this new patch we now do support two possible scenarios.

# Scenario 1
A modder wants to set always this flag, no matter what. The syntax to achieve it remains the same as specified in #34 
```xml
<?xml version="1.0"?>
<ModInfo>
  <Author>Julian Xhokaxhiu</Author>
  <Version>0.1</Version>
  <Description>FFNx Config override example</Description>
  <Link>https://github.com/julianxhokaxhiu/FFNx</Link>
  <FFNxConfig>
    <ff7_footsteps>true</ff7_footsteps>
  </FFNxConfig>
</ModInfo>
```

# Scenario 2
A modder wants to set a flag, but only when a given option has been enabled. The syntax to achieve this scenario is the following:
```xml
<?xml version="1.0"?>
<ModInfo>
  <Author>Julian Xhokaxhiu</Author>
  <Version>0.1</Version>
  <Description>FFNx Config override example</Description>
  <Link>https://github.com/julianxhokaxhiu/FFNx</Link>
  <ConfigOption>
    <Type>Bool</Type>
    <Default>0</Default>
    <ID>Footsteps</ID>
    <Name>Footsteps</Name>
    <Description>Enable Footstep audio.</Description>
    <Option Value="0" Name=""/>
    <Option Value="1" Name=""/>
  </ConfigOption>
  <FFNxConfig>
    <ff7_footsteps Footsteps="1">true</ff7_footsteps>
  </FFNxConfig>
</ModInfo>
```
Please note that `ff7_footsteps` now has a new attribute, which is the `Option` -> `ID` tag name ( in this case `Footsteps` ) and its expected value ( the 7th code treats possible option values always as an int, so you can put basically only numbers in the attribute value ), in this case `1`.

The code will then check, for each flag specified, if ALL of the written attributes do match. If at least one of them will not, the flag will NOT be set and the code will move on. There's no limit on how many Attributes ( Options ) you can specify, although it matters the way you write it: attributes are Case-Sensitive ( so if your option ID is written `footSteps`, the attribute in the flag node has to be written as well as `footSteps` ).

I've tested this code already on my own end and it seems to work fine, although feel free to check it also on your own side and feel free to merge when you think it's good enough to pass.