### PR TITLE
Fix crash on startup

### DIFF
--- a/7thHeaven.Code/Sys.cs
+++ b/7thHeaven.Code/Sys.cs
@@ -208,7 +208,7 @@ namespace Iros._7th.Workshop
         {
             get
             {
-                return Path.Combine(Sys.InstallPath, "FFNx.toml");
+                return Sys.InstallPath != null ? Path.Combine(Sys.InstallPath, "FFNx.toml") : null;
             }
         }
         public static string PathToGameDriverUiXml(string appLanguage = null)


### PR DESCRIPTION
`Sys.InstallPath` is `null` when initializing the property `PathToFFNxToml` on a cold boot.
It will contain a value only once the user will click "Save" on the General Settings window.

Fixes #35