### PR TITLE
Proper SFX and Music defaults for 7H_GameDriver_UI.xml

### DIFF
--- a/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
+++ b/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
@@ -208,7 +208,7 @@
     <Group>Advanced</Group>
     <Name>Music Option</Name>
     <Description>Use VGMStream to play OGG Vorbis high-quality music. Required for music mods. Otherwise, standard MIDI is used.</Description>
-    <DefaultValue>use_external_music = true</DefaultValue>
+    <DefaultValue>use_external_music = false</DefaultValue>
     <Option>
       <Text>VGMStream (Recommended)</Text>
       <Settings>use_external_music = true</Settings>
@@ -223,7 +223,7 @@
     <Group>Advanced</Group>
     <Name>SFX Option</Name>
     <Description>Use VGMStream to play OGG Vorbis high-quality SFX effects. Required for SFX mods. Otherwise, native audio.dat is used.</Description>
-    <DefaultValue>use_external_sfx = true</DefaultValue>
+    <DefaultValue>use_external_sfx = false</DefaultValue>
     <Option>
       <Text>VGMStream (Recommended)</Text>
       <Settings>use_external_sfx = true</Settings>


### PR DESCRIPTION
Proper defaults for music and SFX for use without any mods. 7h currently has music and sfx set to VGMStream=true by default. This wasn't an issue before because the false flags were being inherited from FFNx until now. We've already had a couple people confused why they're getting no SFX when they're not using a SFX mod. Same with music... Now we have the ability for mods to activate these flags only when necessary as well.