### PR TITLE
FFNx: Always use the latest config state available on disk

### DIFF
--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -482,6 +482,7 @@ namespace SeventhHeaven.Classes
                 //
                 // Inherit FFNx Config keys from each mod
                 //
+                Sys.FFNxConfig.Reload();
                 Sys.FFNxConfig.Backup();
                 foreach (RuntimeMod mod in runtimeProfile.Mods)
                 {


### PR DESCRIPTION
This fixes a small bug that happens when you change the `FFNx.toml` file while having 7th opened and then you launch the game.

**Expected Behavior:**
7th launches the game using the `FFNx.toml` flags state, it creates a backup, it applies mod desired config and it launches the game. User expectes to have mod loaded correctly and its custom flags set before launching ( for eg. `trace_all = yes` ).

**Current Behavior:**
If I set the flag `trace_all = yes` and then I launch the game, 7th will keep in memory the flag as false ( as it parsed the file on 7th launch ), and when it will backup the file and apply new configuration flags it will keep the flag as `false` despite you having it set to true.