### PR TITLE
Ffnx config updates

### DIFF
--- a/7thHeaven.Code/FFNxConfigManager.cs
+++ b/7thHeaven.Code/FFNxConfigManager.cs
@@ -61,6 +61,16 @@ namespace Iros._7th.Workshop.ConfigSettings
             }
         }
 
+        public void Set<T>(string key, List<T> value)
+        {
+            TomlArray ta = new TomlArray();
+            foreach (T s in value)
+            {
+                ta.Add(s);
+            }
+            _toml[key] = ta;
+        }
+
         public bool IsSetWithValue(string key, string value)
         {
             switch (_toml[key])

--- a/7thHeaven.Code/Sys.cs
+++ b/7thHeaven.Code/Sys.cs
@@ -620,8 +620,6 @@ namespace Iros._7th.Workshop
 
         public static bool ValidateAndRemoveDeletedMods()
         {
-            bool deletedInvalidMod = false;
-
             foreach (InstalledItem mod in Sys.Library.Items.ToList())
             {
                 if (!mod.ModExistsOnFileSystem())
@@ -630,11 +628,10 @@ namespace Iros._7th.Workshop
                     Sys.ActiveProfile.Items.RemoveAll(p => p.ModID == mod.ModID);
                     Mod details = mod.CachedDetails ?? new Mod();
                     Sys.Message(new WMessage { Text = $"{details.Name} - [{StringKey.ModCouldNotBeFoundHasItBeenDeleted}]", TextTranslationKey = StringKey.ModCouldNotBeFoundHasItBeenDeleted });
-                    deletedInvalidMod = true;
                 }
             }
 
-            return deletedInvalidMod;
+            return false;
         }
     }
 }

--- a/7thWrapperLib/Profile.cs
+++ b/7thWrapperLib/Profile.cs
@@ -920,7 +920,19 @@ namespace _7thWrapperLib
                     var flag = new FFNxFlag();
 
                     flag.Key = child.Name;
-                    flag.Value = child.InnerText;
+                    if (child.ChildNodes.Count > 1)
+                    {
+                        List<string> items = new List<string>();
+                        foreach (XmlNode item in child.ChildNodes)
+                        {
+                            items.Add(item.InnerText);
+                        }
+                        flag.Values = items;
+                    }
+                    else
+                    {
+                        flag.Value = child.InnerText;
+                    }
 
                     foreach (XmlAttribute attr in child.Attributes)
                         flag.Attributes.Add(attr.Name, int.Parse(attr.Value));
@@ -1318,12 +1330,14 @@ namespace _7thWrapperLib
     {
         public string Key;
         public string Value;
+        public List<string> Values;
         public Dictionary<string, int> Attributes;
 
         public FFNxFlag()
         {
             Key = String.Empty;
             Value = String.Empty;
+            Values = new List<string>();
             Attributes = new Dictionary<string, int>();
         }
     }

--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -497,7 +497,17 @@ namespace SeventhHeaven.Classes
 
                         if (addConfig)
                         {
-                            if (Sys.FFNxConfig.HasKey(flag.Key)) Sys.FFNxConfig.Set(flag.Key, flag.Value);
+                            if (Sys.FFNxConfig.HasKey(flag.Key))
+                            {
+                                if (flag.Values.Count > 0)
+                                {
+                                    Sys.FFNxConfig.Set(flag.Key, flag.Values);
+                                }
+                                else
+                                {
+                                    Sys.FFNxConfig.Set(flag.Key, flag.Value);
+                                }
+                            }
                         }
                     }
                 }
@@ -777,7 +787,10 @@ namespace SeventhHeaven.Classes
                         if (Sys.Settings.GameLaunchSettings.AutoUnmountGameDisc && Instance.DidMountVirtualDisc)
                         {
                             Instance.RaiseProgressChanged(ResourceHelper.Get(StringKey.AutoUnmountingGameDisc));
-                            Instance.DiscMounter.UnmountVirtualGameDisc();
+                            if (Instance.DiscMounter != null)
+                            {
+                                Instance.DiscMounter.UnmountVirtualGameDisc();
+                            }
                             Instance.DiscMounter = null;
                         }
 


### PR DESCRIPTION
Added support for mods to use config array for FFNx is done though groups of  `<item>` for the properties.

E.G
```xml
<disable_animated_textures_on_field ATA="1">
    <item>ancnt1</item>
    <item>ancnt2</item>
    <item>ancnt3</item>
    <item>ancnt4</item>
    <item>blin1</item>
  </disable_animated_textures_on_field>
```