### PR TITLE
Skip app launch if silent install is requested

### DIFF
--- a/.iss/installer.iss
+++ b/.iss/installer.iss
@@ -46,7 +46,7 @@ Name: "{group}\TurBoLog"; Filename: {app}\TurBoLog.exe;
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"; IconFilename: "{app}\uninstall.ico"
 
 [Run]
-Filename: "{app}\7th Heaven.exe"; Flags: nowait postinstall runascurrentuser; Description: "Launch {#MyAppName}"
+Filename: "{app}\7th Heaven.exe"; Flags: nowait postinstall runascurrentuser skipifsilent; Description: "Launch {#MyAppName}"
 
 [InstallDelete]
 Name: {app}\7thWorkshop\catalog.xml; Type: files


### PR DESCRIPTION
Currently there is a step to launch the app once the installer is complete. If /SILENT or /VERYSILENT is used, this happens automatically.

Added a piece to skip launching the app on a silent install, to streamline Linux installs (https://github.com/tsunamods-codes/7th-Heaven/issues/19) 