### PR TITLE
Extend default width main window

### DIFF
--- a/SeventhHeavenUI/Windows/MainWindow.xaml
+++ b/SeventhHeavenUI/Windows/MainWindow.xaml
@@ -14,7 +14,7 @@
         Loaded="Window_Loaded"
         SizeChanged="Window_SizeChanged"
         Closing="Window_Closing"
-        Height="600" Width="1100"
+        Height="600" Width="1250"
         MinHeight="520" MinWidth="870">
     <Window.Resources>
 


### PR DESCRIPTION
Extend window to compensate for extra column, still fits 720p screens.