### PR TITLE
Fix fileKey string for IRO that start from root mod folder

### DIFF
--- a/7thWrapperLib/Wrap.cs
+++ b/7thWrapperLib/Wrap.cs
@@ -362,7 +362,10 @@ namespace _7thWrapperLib {
             {
                 if (filename.StartsWith(folderPath, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    string fileKey = filename.Substring(folderPath.Length + 1).ToLower();
+                    int pathOffset = 1;
+                    if (folderPath.Length == 0) // Fix the offset when folderPath is empty string (no need to skip "/")
+                        pathOffset = 0;
+                    string fileKey = filename.Substring(folderPath.Length + pathOffset).ToLower();
                     if (!_profile.mappedFiles.ContainsKey(fileKey))
                         _profile.mappedFiles.Add(fileKey, new List<OverrideFile>());
 


### PR DESCRIPTION
There was a problem with FFNx FF7 music not loading. It was because IROs that do not use folder of mod.xml, starts from root IRO folder, so there was no need to get the substring starting from index 1. 

Regarding the counterpart folder mods, there is no need in that case.