### PR TITLE
RegistryHelper: Fix double backslash path

### DIFF
--- a/7thHeaven.Code/RegistryHelper.cs
+++ b/7thHeaven.Code/RegistryHelper.cs
@@ -235,7 +235,8 @@ namespace _7thHeaven.Code
                 case RegistryValueKind.String:
                 case RegistryValueKind.Unknown:
                     regType = "REG_SZ";
-                    value = $"\"{value.ToString().Replace("\"", "\"\"").Replace("%", "%%").Replace("\\", "\\\\")}\"";
+                    bool lastCharIsEscape = value.ToString()[value.ToString().Length - 1].Equals('\\');
+                    value = $"\"{value.ToString().Replace("\"", "\"\"").Replace("%", "%%")}{(lastCharIsEscape ? "\\" : "")}\"";
                     break;
             }
 


### PR DESCRIPTION
Since there is a problem with having registry paths with double backslash, I removed the replace adding another backslash and only added a new backslash to the end of the path if required.

I tested it by changing the path of FF7 install dir, and it is working.