### PR TITLE
RegistryHelper: Fix equality registry value for Guid

### DIFF
--- a/7thHeaven.Code/RegistryHelper.cs
+++ b/7thHeaven.Code/RegistryHelper.cs
@@ -365,9 +365,8 @@ namespace _7thHeaven.Code
 
             if (newValue is Guid)
             {
-                Guid currentConverted = currentValue == null ? new Guid() : new Guid(currentValue as byte[]);
-
-                isValuesEqual = currentConverted.Equals(newValue);
+                bool isCurrentValueValid = currentValue != null && (currentValue as byte[]).Length == 16;
+                isValuesEqual = isCurrentValueValid && new Guid(currentValue as byte[]).Equals(newValue);
             }
             else
             {


### PR DESCRIPTION
The issue previously is that `new Guid(currentValue as byte[])` requires currentValue to be exactly 16 bytes of length, otherwise it throws an error. With this change, even if the current guid value is wrong (e.g. less than 16 byte or null), it will be overwritten.