### PR TITLE
Update using xcopy instead of robocopy

### DIFF
--- a/SeventhHeavenUI/Classes/UpdateChecker.cs
+++ b/SeventhHeavenUI/Classes/UpdateChecker.cs
@@ -228,7 +228,7 @@ namespace SeventhHeaven.Classes
 @echo Waiting for 7th Heaven to be closed, please wait...
 @taskkill /IM ""7th Heaven.exe"" /F >NUL 2>NUL
 @timeout /t 5 /nobreak
-@robocopy ""{sourcePath}"" ""{Sys._7HFolder}"" /S /MOV >NUL 2>NUL
+@xcopy ""{sourcePath}"" ""{Sys._7HFolder}"" /S /Y >NUL 2>NUL
 @echo Waiting for the update to take place, please wait...
 @timeout /t 5 /nobreak
 @rmdir /s /q ""{sourcePath}""


### PR DESCRIPTION
Robocopy is broken in Wine/Proton, which has forced us to use some awkward workarounds to get 7th Heaven's updater working on the Steam Deck.

After trying and failing for several hours to find a workaround that persists after a proton update, I had no success. Even if we can get it working, I think it's a lot more sensible to just change the behaviour of the temporary `update.bat` that 7th Heaven uses to update itself, rather than have a wrapper on the Steam Deck just to handle something as simple as moving files.

This PR simply replaces the use of `robocopy` with `xcopy`. Since `xcopy` is deprecated, I attempted to use `move` but was met with a sharing violation that I couldn't find a way around.

I tested this on both Windows and Steam Deck, and it seems to function as expected but I would appreciate having someone double-check.