### PR TITLE
Convert profile.xml to profile.txt for crashlog

### DIFF
--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -1689,7 +1689,7 @@ namespace SeventhHeaven.Classes
                 Profile currentProfile = Util.Deserialize<Profile>(Sys.PathToCurrentProfileFile);
                 IEnumerable<string> profileDetails = currentProfile.GetDetails();
                 File.WriteAllLines(Path.Combine(Sys.PathToTempFolder, "profile.txt"), profileDetails);
-                archive.AddEntry("profile.txt", Path.Combine(Sys.InstallPath, "profile.txt"));
+                archive.AddEntry("profile.txt", Path.Combine(Sys.PathToTempFolder, "profile.txt"));
 
                 // =================================================================================================
 

--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -1688,7 +1688,7 @@ namespace SeventhHeaven.Classes
                 // Convert profile.xml to profile.txt
                 Profile currentProfile = Util.Deserialize<Profile>(Sys.PathToCurrentProfileFile);
                 IEnumerable<string> profileDetails = currentProfile.GetDetails();
-                File.WriteAllLines(Path.Combine(Sys.InstallPath, "profile.txt"), profileDetails);
+                File.WriteAllLines(Path.Combine(Sys.PathToTempFolder, "profile.txt"), profileDetails);
                 archive.AddEntry("profile.txt", Path.Combine(Sys.InstallPath, "profile.txt"));
 
                 // =================================================================================================

--- a/SeventhHeavenUI/Classes/GameLauncher.cs
+++ b/SeventhHeavenUI/Classes/GameLauncher.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
 using System.Xml;
+using Profile = Iros._7th.Workshop.Profile;
 
 namespace SeventhHeaven.Classes
 {
@@ -1682,9 +1683,13 @@ namespace SeventhHeaven.Classes
                 // === 7th files ===
                 archive.AddEntry("7thWrapperLoader.log", Path.Combine(Sys.InstallPath, "7thWrapperLoader.log"));
                 archive.AddEntry("applog.txt", File.Open(Sys.PathToApplog, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
-                archive.AddEntry("profile.xml", Sys.PathToCurrentProfileFile);
                 archive.AddEntry("settings.xml", Sys.PathToSettings);
                 archive.AddEntry("registry_transaction.bat", Path.Combine(Sys.PathToTempFolder, "registry_transaction.bat"));
+                // Convert profile.xml to profile.txt
+                Profile currentProfile = Util.Deserialize<Profile>(Sys.PathToCurrentProfileFile);
+                IEnumerable<string> profileDetails = currentProfile.GetDetails();
+                File.WriteAllLines(Path.Combine(Sys.InstallPath, "profile.txt"), profileDetails);
+                archive.AddEntry("profile.txt", Path.Combine(Sys.InstallPath, "profile.txt"));
 
                 // =================================================================================================
 


### PR DESCRIPTION
There was some talk in Discord about using the profile.txt that is created with `ViewProfileDetails()` in `OpenProfileViewModel.cs` than providing the profile.xml, since the former is much more readable.

There may be a better place in the codebase for this but I didn't go too deep because this is only running when the game crashes anyway. Open to suggestions.