### PR TITLE
Add auto-run to Game Driver Settings

### DIFF
--- a/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
+++ b/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
@@ -290,6 +290,15 @@
 
   <Setting xsi:type="Checkbox">
     <Group>Advanced</Group>
+    <Name>Auto Run</Name>
+    <Description>Walk or run depending on how much the left analog stick is tilted.</Description>
+    <DefaultValue>enable_auto_run = false</DefaultValue>
+    <TrueSetting>enable_auto_run = true</TrueSetting>
+    <FalseSetting>enable_auto_run = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>Advanced</Group>
     <Name>Steam Compatibility</Name>
     <Description>Enable Steam features (Game activity, Controller, and Achievements). REQUIRES Steam to be running.</Description>
     <DefaultValue>enable_steam_achievements = false</DefaultValue>


### PR DESCRIPTION
I didn't even know FFNx had this option built-in until the other day. The Gameplay Tweaks mod uses its own implementation that has recently started causing crashes for people on Steam Deck.

Should we just combine this setting with the Analogue Controls option to avoid cluttering the UI? Do most people prefer holding B to run?

Screenshot:
![image](https://github.com/tsunamods-codes/7th-Heaven/assets/11805686/e23756fc-4fdf-473e-885d-89666af88cf0)

Note: This will require translation for other languages. I wasn't sure if I should use Google Translate or if that was generally taken care of by people who know how to speak them.