### PR TITLE
UpdateChecker: Use the installer to auto-update

### DIFF
--- a/SeventhHeavenUI/Classes/UpdateChecker.cs
+++ b/SeventhHeavenUI/Classes/UpdateChecker.cs
@@ -214,7 +214,7 @@ namespace SeventhHeaven.Classes
 @echo ----------------------------------------------------
 @echo Waiting for the update to take place, please wait...
 @echo ATTENTION: The update may ask you to install some dependencies. It is safe to proceed with the installation when prompted.
-@start """" /wait /d ""{Sys._7HFolder}"" ""{installerFullPath}"" /SILENT /DIR=""{Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}""
+@start """" /wait /d ""{Sys._7HFolder}"" ""{installerFullPath}"" /SILENT /DIR=""{Sys._7HFolder}""
 @echo ----------------------------------------------------
 @echo Update completed. Restarting 7th Heaven now...
 @timeout /t 5 /nobreak >NUL 2>NUL


### PR DESCRIPTION
Starting this PR we will use the EXE installer instead of the ZIP release to manage upgrades.

This will allow us to scale better in future even when the stacks are bumped.

The user behavior remains basically the same:
1. 7thHeaven downloads the EXE
2. It will run it in silent mode
  - If missing dependencies are not installed the installer will prompt the user to install them
  - if dependencies are met it will continue the installation as usual on the path where 7th is currently being run
3. It will automatically restart 7th Heaven after the upgrade