### PR TITLE
Gardening: Username preference and missing <CRLF>

### DIFF
--- a/SeventhHeavenUI/Resources/Help/index.html
+++ b/SeventhHeavenUI/Resources/Help/index.html
@@ -213,10 +213,10 @@ Leonhart<br>
 LittleTale/youffie<br>
 OatBran<br>
 Rukenu<br>
-Satsuki
-nuadaxxx
-jtd
-vyzzuvazzadth
+Satsuki<br>
+Nuada<br>
+jtd<br>
+vyzzuvazzadth<br>
 
 <b><h3>UltraSound Plugin</h2></b>
 ficedula<br>


### PR DESCRIPTION
Nuada would prefer a different credential, and noticed that npp had eaten the "br" tags