### PR TITLE
Add Auto-Run Toggle to Controls Menu

### DIFF
--- a/SeventhHeavenUI/Resources/Languages/StringResources.br.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.br.xaml
@@ -1193,6 +1193,8 @@ Você quer aplicar essa configuração e tentar de novo?</system:String>
     <system:String x:Key="Presets">Predefinições:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Habilitar Suporte para Controle de PS4</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Permite usar um controle de PS4 com o jogo (driver SCP deve estar instalado)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Salvas alterações aos controles.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Abrir Tela de Controles de Jogo</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.de.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.de.xaml
@@ -1200,6 +1200,8 @@ Möchten Sie die Einstellung übernehmen und es erneut versuchen?</system:String
     <system:String x:Key="Presets">Voreinstellungen:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">PS4 mit XInput</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Ermöglicht die Verwendung eines PS4-Controllers als XInput-Gerät und die Steuerung der Maus mit dem Controller-Touchpad im Spiel (SCP-Treiber muss installiert sein).</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Steuerung speichern.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Öffnet die Controllereinstellungen</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.de.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.de.xaml
@@ -1200,8 +1200,8 @@ Möchten Sie die Einstellung übernehmen und es erneut versuchen?</system:String
     <system:String x:Key="Presets">Voreinstellungen:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">PS4 mit XInput</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Ermöglicht die Verwendung eines PS4-Controllers als XInput-Gerät und die Steuerung der Maus mit dem Controller-Touchpad im Spiel (SCP-Treiber muss installiert sein).</system:String>
-    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
-    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
+    <system:String x:Key="EnableAutoRun">Automatisches Rennen aktivieren</system:String>
+    <system:String x:Key="AutoRunTooltip">Dies ermöglicht Gehen oder Rennen, je nachdem, wie stark der linke Analogstick geneigt ist (erfordert eine aktivierte Analogsteuerung).</system:String>
     <system:String x:Key="SaveChangesTooltip">Steuerung speichern.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Öffnet die Controllereinstellungen</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.es.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.es.xaml
@@ -1202,6 +1202,8 @@ Por último, si quieres usar archivos .OGG de alta calidad, cambia la opción de
     <system:String x:Key="Presets">Ajustes preestablecidos:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Activar Driver XInput de PS4</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Permite usar un mando de PS4 con el juego como un dispositivo XInput y controlar el ratón con el panel táctil (debe estar instalado el driver SCP)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Guardar los cambios de los controles.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Abrir la ventana Dispositivos de juego</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.fr.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.fr.xaml
@@ -1189,6 +1189,8 @@ Voulez-vous appliquer ce réglage et essayer à nouveau ?</system:String>
     <system:String x:Key="Presets">Préréglages :</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Activer le support des manettes PS4</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Permet d'utiliser une manette PS4 avec le jeu (le pilote SCP doit être installé)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Enregistrer les modifications apportées aux contrôles.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Ouvrir la fenêtre des contôleurs de jeu</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.gr.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.gr.xaml
@@ -1195,6 +1195,8 @@
     <system:String x:Key="Presets">Προεπιλογές:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Ενεργοποίηση υποστήριξης χειριστηρίου PS4</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Επιτρέπει τη χρήση ενός χειριστηρίου PS4 με το παιχνίδι (πρέπει να είναι εγκατεστημένο το πρόγραμμα οδήγησης SCP)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Αποθήκευση αλλαγών στα στοιχεία ελέγχου.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Άνοιγμα Παραθύρου Χειριστηρίων Παιχνιδιού</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.it.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.it.xaml
@@ -1193,6 +1193,8 @@ Vuoi applicare questa modifica e riprovare?</system:String>
     <system:String x:Key="Presets">Preset:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Abilita Supporto per Controller PS4</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Consente di usare un controller PS4 per giocare (i driver SCP devono essere già presenti)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Salva cambiamenti.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Apri Finestra Controlli di Gioco</system:String>

--- a/SeventhHeavenUI/Resources/Languages/StringResources.ja.xaml
+++ b/SeventhHeavenUI/Resources/Languages/StringResources.ja.xaml
@@ -1181,6 +1181,8 @@ Do you want to apply the setting and try again?</system:String>
     <system:String x:Key="Presets">Presets:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Enable PS4 Controller Support</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Allows to use a PS4 controller with the game (SCP driver must be installed)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Save changes to controls.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Open Game Controllers Window</system:String>

--- a/SeventhHeavenUI/Resources/StringResources.xaml
+++ b/SeventhHeavenUI/Resources/StringResources.xaml
@@ -1200,6 +1200,8 @@ Do you want to apply the setting and try again?</system:String>
     <system:String x:Key="Presets">Presets:</system:String>
     <system:String x:Key="EnablePS4ControllerSupport">Enable PS4 XInput Driver</system:String>
     <system:String x:Key="PS4ControllerSupportTooltip">Allows to use a PS4 controller with the game as an XInput device and control the mouse with the controller touchpad (SCP driver must be installed)</system:String>
+    <system:String x:Key="EnableAutoRun">Enable Auto Run</system:String>
+    <system:String x:Key="AutoRunTooltip">This flag enables walking or running depending on how much the left analog stick is tilted (requires analog controls enabled)</system:String>
     <system:String x:Key="SaveChangesTooltip">Save changes to controls.</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">Open Game Controllers Window</system:String>

--- a/SeventhHeavenUI/ViewModels/ControlMappingViewModel.cs
+++ b/SeventhHeavenUI/ViewModels/ControlMappingViewModel.cs
@@ -47,6 +47,8 @@ namespace SeventhHeaven.ViewModels
         private bool _isPs4SupportChecked;
         private bool _isInstallingDriver;
 
+        private bool _isAutoRunChecked;
+
         private string _okKeyboardText;
         private string _cancelKeyboardText;
         private string _menuKeyboardText;
@@ -725,6 +727,24 @@ namespace SeventhHeaven.ViewModels
             get
             {
                 return !_defaultControlNames.Any(s => s.Equals(SelectedGameConfigOption, StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
+
+
+        public bool IsAutoRunChecked
+        {
+            get
+            {
+                return Convert.ToBoolean(Sys.FFNxConfig.Get("enable_auto_run"));
+            }
+            set
+            {
+                if (value)
+                {
+                    Sys.FFNxConfig.Set("enable_analogue_controls", "true");
+                }
+                Sys.FFNxConfig.Set("enable_auto_run", value.ToString());
+                Sys.FFNxConfig.Save();
             }
         }
 

--- a/SeventhHeavenUI/ViewModels/ControlMappingViewModel.cs
+++ b/SeventhHeavenUI/ViewModels/ControlMappingViewModel.cs
@@ -47,8 +47,6 @@ namespace SeventhHeaven.ViewModels
         private bool _isPs4SupportChecked;
         private bool _isInstallingDriver;
 
-        private bool _isAutoRunChecked;
-
         private string _okKeyboardText;
         private string _cancelKeyboardText;
         private string _menuKeyboardText;
@@ -731,7 +729,7 @@ namespace SeventhHeaven.ViewModels
         }
 
 
-        public bool IsAutoRunChecked
+        public static bool IsAutoRunChecked
         {
             get
             {

--- a/SeventhHeavenUI/Windows/ControlMappingWindow.xaml
+++ b/SeventhHeavenUI/Windows/ControlMappingWindow.xaml
@@ -515,6 +515,16 @@
                       Grid.Row="2"
                       Grid.ColumnSpan="4"/>
 
+            <CheckBox x:Name="chkAutoRun"
+                      Style="{StaticResource ToggleSwitchCheckbox}"
+                      IsChecked="{Binding IsAutoRunChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                      FontSize="13"
+                      Content="{DynamicResource EnableAutoRun}"
+                      ToolTip="{DynamicResource AutoRunTooltip}"
+                      HorizontalAlignment="Left"
+                      Grid.Row="3"
+                      Grid.ColumnSpan="4"/>
+
             <Button x:Name="btnOpenGameControllersWindow"
                     Style="{StaticResource HyperlinkButton}"
                     Click="btnOpenGameControllersWindow_Click"

--- a/SeventhHeavenUI/Windows/ControlMappingWindow.xaml
+++ b/SeventhHeavenUI/Windows/ControlMappingWindow.xaml
@@ -424,7 +424,7 @@
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
-                <RowDefinition Height="20"/>
+                <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
@@ -532,7 +532,7 @@
                     Grid.ColumnSpan="4"
                     HorizontalAlignment="Left"
                     FontSize="11"
-                    Grid.Row="4"/>
+                    Grid.Row="5"/>
 
         </Grid>
     </Grid>


### PR DESCRIPTION
As requested here: https://github.com/tsunamods-codes/7th-Heaven/issues/162

Previously I suggested adding this to the Game Driver window but we decided it was best to leave this out.

I think this fits better here, and it may even make more sense for Analog Controls to be moved here as well, but I figured I'd open a PR so we can discuss this change in the open.

This directly affects the FFNx.toml and enables Analog Controls if it is not already enabled (I believe that needs to be enabled for this option to take effect, but if I'm wrong I can change this behaviour).

![image](https://github.com/tsunamods-codes/7th-Heaven/assets/11805686/f7bc3615-6d5c-49ec-80b5-4be29644513d)
