### PR TITLE
iss: Allow downgrades via 7th

### DIFF
--- a/.iss/installer.iss
+++ b/.iss/installer.iss
@@ -49,7 +49,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
 
 [Files]
-Source: "{#MyAppPath}\bin\{#MyAppRelease}\{#MyAppTargetFramework}\*"; DestDir: "{app}"; Flags: recursesubdirs
+Source: "{#MyAppPath}\bin\{#MyAppRelease}\{#MyAppTargetFramework}\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
 Source: "{#MyAppPath}\7H.ico"; DestDir: "{app}"; DestName: "uninstall.ico"
 Source: "netcorecheck.exe"; Flags: dontcopy noencryption
 Source: "netcorecheck_x64.exe"; Flags: dontcopy noencryption


### PR DESCRIPTION
Switching from Canary to Stable does not seem to work because of a missing flag in the Inno config.

This change will allow downgrading using the new updater method.

I tested it by building 7th Heaven in Release mode, updating to stable through the UI, and then using the Inno script to build a new installer.  I also changed the Inno script to Release mode so it would point to the correct path (I changed this back before pushing).

Then I updated my build to canary and ran the stable release installer from GitHub and ran 7th Heaven. Still on 3.3.0.1.

Then I ran the `mysetup.exe` from the `.iss/Output` folder and launched 7th Heaven and it seems to install 3.3.0.0 properly.


I think a new installer needs to be built for the current stable release before this will actually work.