### PR TITLE
SeventhHeavenUI: Remove 8x/16x MSAA as selectable options

### DIFF
--- a/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
+++ b/SeventhHeavenUI/Resources/7H_GameDriver_UI.xml
@@ -85,7 +85,7 @@
   <Setting xsi:type="DropDown">
     <Group>Graphics</Group>
     <Name>Antialiasing</Name>
-    <Description>Applies 2x/4x/8x/16x MSAA filtering. Reduces jagged edges and improves image quality. Can severely impact performance.</Description>
+    <Description>Applies 2x or 4x MSAA filtering. Reduces jagged edges and improves image quality. Can severely impact performance.</Description>
     <DefaultValue>enable_antialiasing = 0</DefaultValue>
     <Option>
       <Text>Off</Text>
@@ -98,14 +98,6 @@
     <Option>
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
-    </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
     </Option>
   </Setting>
 

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.br.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.br.xml
@@ -99,14 +99,6 @@
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.de.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.de.xml
@@ -99,14 +99,6 @@
       <Text>4xMSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8xMSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16xMSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.es.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.es.xml
@@ -99,14 +99,6 @@
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.fr.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.fr.xml
@@ -99,14 +99,6 @@
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.gr.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.gr.xml
@@ -99,14 +99,6 @@
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.it.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.it.xml
@@ -99,14 +99,6 @@
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">

--- a/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.ja.xml
+++ b/SeventhHeavenUI/Resources/Languages/7H_GameDriver_UI.ja.xml
@@ -99,14 +99,6 @@
       <Text>4x MSAA</Text>
       <Settings>enable_antialiasing = 4</Settings>
     </Option>
-    <Option>
-      <Text>8x MSAA</Text>
-      <Settings>enable_antialiasing = 8</Settings>
-    </Option>
-    <Option>
-      <Text>16x MSAA</Text>
-      <Settings>enable_antialiasing = 16</Settings>
-    </Option>
   </Setting>
 
   <Setting xsi:type="Checkbox">


### PR DESCRIPTION
Cranking MSAA too high causes visual artifacts on 4k screens, and increases the likelihood of bgfx device disconnects on older GPU hardware.