### PR TITLE
Gardening: Adjust piracy/exe verification message

### DIFF
--- a/AppUI/Resources/StringResources.xaml
+++ b/AppUI/Resources/StringResources.xaml
@@ -746,7 +746,7 @@ Once done, do close the game and the launcher, and finally retry to click Play h
     <system:String x:Key="FileNotFoundAborting">file not found. Aborting ...</system:String>
     <system:String x:Key="Ff7ExeNotFoundYouMayNeedToConfigure">FF7.exe not found. You may need to configure 7H using the Settings>General Settings menu.</system:String>
     <system:String x:Key="VerifyingInstalledGameIsCompatible">Verifying installed game is compatible ...</system:String>
-    <system:String x:Key="ErrorCodeYarr">Error code: YARR! Unable to continue. This copy of FF7 appears to be pirated. Please purchase a genuine copy of the game. If this copy is genuine, please ask for help on the Qhimm forums.</system:String>
+    <system:String x:Key="ErrorCodeYarr">YUFFIE: Urrk!! Something's wrong with your installation, and it... ulp... Use Steam's "Verify my files" tool or reinstall from CD to fix.</system:String>
     <system:String x:Key="VerifyingGameIsNotInstalledInProtectedFolder">Verifying game is not installed in a System/Protected folder ...</system:String>
 
     <system:String x:Key="Ff7IsCurrentlyInstalledInASystemFolder" xml:space="preserve">FF7 is currently installed in a System folder which can cause mods not to work. It is recommended you install it at C:\Games\Final Fantasy VII


### PR DESCRIPTION
We haven't had a true pirate to make fun of in Discord for a very long time, but altered/corrupt EXE files show up fairly frequently.  Adjust the message to better reflect this.