### PR TITLE
Update StringResources.zh.xaml

### DIFF
--- a/AppUI/Resources/Languages/StringResources.zh.xaml
+++ b/AppUI/Resources/Languages/StringResources.zh.xaml
@@ -1234,5 +1234,5 @@
     <system:String x:Key="App4GBPatchRequired">确保游戏 exe 已应用4GB补丁...</system:String>
     <system:String x:Key="App4GBPatchApplied">4GB补丁应用成功。</system:String>
 
-    <system:String x:Key="OpenSaveGamePath">>打开保存目录...</system:String>
+    <system:String x:Key="OpenSaveGamePath">打开保存目录...</system:String>
 </ResourceDictionary>


### PR DESCRIPTION
delete extra "<" 
by the way, all language can't show correct translation in "Settings-Game Driver-Graphics-Display:" and "Settings-Game Driver-Graphics-Resolution:" untrasnlated strings are "Primary Display" and "Auto"