### PR TITLE
Add an option to launch the game exe directly

### DIFF
--- a/AppCore/Settings.cs
+++ b/AppCore/Settings.cs
@@ -35,7 +35,8 @@ namespace Iros.Workshop {
         Show7HInFileExplorerContextMenu,
         WarnAboutModCode,
         AutoUpdateMods,
-        AutoSortMods
+        AutoSortMods,
+        LaunchExeDirectly
     }
 
     public enum AppUpdateChannelOptions

--- a/AppUI/Resources/StringResources.xaml
+++ b/AppUI/Resources/StringResources.xaml
@@ -669,6 +669,7 @@ Click 'Cancel' to stop the process.</system:String>
     <system:String x:Key="AutoUpdateModsByDefault">Auto Update Mods By Default</system:String>
     <system:String x:Key="IgnoreModCompatibilityRestrictions">Ignore Mod Compatibility Restrictions</system:String>
     <system:String x:Key="CheckFor7thHeavenUpdatesAutomatically">Check For 7th Heaven Updates Automatically</system:String>
+    <system:String x:Key="LaunchExeDirectly">Launch Exe Directly</system:String>
 
     <system:String x:Key="OpenIrosLinksWith7thHeaven">Open iros:// links with 7th Heaven</system:String>
     <system:String x:Key="OpenModFilesWith7thHeaven">Open Mod Files with 7th Heaven</system:String>

--- a/AppUI/ViewModels/GeneralSettingsViewModel.cs
+++ b/AppUI/ViewModels/GeneralSettingsViewModel.cs
@@ -25,6 +25,7 @@ namespace AppUI.ViewModels
         private bool _activateInstalledModsAuto;
         private bool _importLibraryFolderAuto;
         private bool _checkForUpdatesAuto;
+        private bool _launchExeDirectly;
         private bool _bypassCompatibilityLocks;
         private bool _openIrosLinks;
         private bool _openModFilesWith7H;
@@ -180,6 +181,32 @@ namespace AppUI.ViewModels
                 NotifyPropertyChanged();
             }
         }
+
+        public bool LaunchExeDirectly
+        {
+            get
+            {
+                return _launchExeDirectly;
+            }
+            set
+            {
+                _launchExeDirectly = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+        public Visibility LaunchExeDirectlyVisibility
+        {
+            get
+            {
+                if(Sys.Settings.FF7InstalledVersion == FF7Version.Steam || LaunchExeDirectly)
+                {
+                    return Visibility.Visible;
+                }
+                return Visibility.Collapsed;
+            }
+        }
+
 
         public bool BypassCompatibilityLocks
         {
@@ -410,6 +437,10 @@ namespace AppUI.ViewModels
             OpenModFilesWith7H = settings.HasOption(GeneralOptions.OpenModFilesWith7H);
             WarnAboutModCode = settings.HasOption(GeneralOptions.WarnAboutModCode);
             ShowContextMenuInExplorer = settings.HasOption(GeneralOptions.Show7HInFileExplorerContextMenu);
+
+            LaunchExeDirectly = settings.HasOption(GeneralOptions.LaunchExeDirectly);
+
+            NotifyPropertyChanged(nameof(LaunchExeDirectlyVisibility));
         }
 
         public static void AutoDetectSystemPaths(Settings settings)
@@ -702,6 +733,9 @@ namespace AppUI.ViewModels
 
             if (ShowContextMenuInExplorer)
                 newOptions.Add(GeneralOptions.Show7HInFileExplorerContextMenu);
+
+            if (LaunchExeDirectly)
+                newOptions.Add(GeneralOptions.LaunchExeDirectly);
 
 
             return newOptions;

--- a/AppUI/Windows/GeneralSettingsWindow.xaml
+++ b/AppUI/Windows/GeneralSettingsWindow.xaml
@@ -109,6 +109,7 @@
                 <CheckBox Height="25" Content="{DynamicResource AutoUpdateModsByDefault}" IsChecked="{Binding AutoUpdateModsByDefault, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, FallbackValue='True'}" Margin="0,0,0,2"/>
                 <CheckBox Height="25" Content="{DynamicResource IgnoreModCompatibilityRestrictions}" IsChecked="{Binding BypassCompatibilityLocks, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,2"/>
                 <CheckBox Height="25" Content="{DynamicResource CheckFor7thHeavenUpdatesAutomatically}" IsChecked="{Binding CheckForUpdatesAuto, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,2"/>
+                <CheckBox Height="25" Content="{DynamicResource LaunchExeDirectly}" Visibility="{Binding LaunchExeDirectlyVisibility}" IsChecked="{Binding LaunchExeDirectly, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,2"/>
             </StackPanel>
         </GroupBox>
 


### PR DESCRIPTION
This works around an issue where if you're using the Steam version, but with the installation in a different directory (meaning FF7Exe is at a different path than the library install), 7H launches through Steam, which opens the wrong exe / injects mods into the wrong directory.

Additionally, if enabled, this writes a `steam_appid.txt` to the exe directory, which allows the exe to be launched directly, instead of closing and re-opening through the Steam library.
That behavior typically comes from the game checking [SteamAPI_RestartAppIfNecessary](https://partner.steamgames.com/doc/api/steam_api#SteamAPI_RestartAppIfNecessary), which will return false if `steam_appid.txt` is present (this file also lets Steam [know which app is running](https://partner.steamgames.com/doc/api/steam_api#SteamAPI_Init)).