### PR TITLE
Completely retranslated Chinese localization with restored missing text

### DIFF
--- a/AppUI/Resources/Languages/7H_GameDriver_UI.zh.xml
+++ b/AppUI/Resources/Languages/7H_GameDriver_UI.zh.xml
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ConfigSpec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
   <!-- GRAPHICS TAB -->
   <Setting xsi:type="DropDown">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>图形 API</Name>
-    <Description>设置渲染软件。自动根据您的 GPU 选择最佳选项。{0}AMD 显卡使用 OpenGL 可能会导致崩溃。{0}如果遇到游戏闪退、场景黑屏等问题，可依次尝试每个选项，直到游戏正常。</Description>
+    <Description>选择游戏的软件渲染方式。{0}如果遇到游戏闪退、场景黑屏等问题，可依次尝试每个选项，直到游戏正常。{0}DirectX 11是最稳定的选项。AMD显卡不建议选择OpenGL选项。</Description>
     <DefaultValue>renderer_backend = 0</DefaultValue>
     <Option>
-      <Text>自动</Text>
+      <Text>Auto</Text>
       <Settings>renderer_backend = 0</Settings>
     </Option>
     <Option>
@@ -30,9 +30,9 @@
   </Setting>
 
   <Setting xsi:type="DropDown">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>显示器</Name>
-    <Description>设置游戏运行的优先显示器。</Description>
+    <Description>选择游戏运行时的画面投放到哪个显示器上。仅在你的电脑连接了多台显示器的情况下可选。</Description>
     <DefaultValue>display_index = -1</DefaultValue>
     <Option>
       <Text>主显示器</Text>
@@ -41,9 +41,9 @@
   </Setting>
 
   <Setting xsi:type="DropDown">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>分辨率</Name>
-    <Description>设置游戏窗口大小。仅影响窗口模式的分辨率，不影响全屏模式。全屏模式会自动使用当前桌面分辨率。Auto选项会自动使用游戏默认窗口分辨率。</Description>
+    <Description>设置游戏窗口大小。仅影响窗口模式的分辨率，不影响全屏模式。{0}全屏模式会自动使用当前桌面分辨率。{0}Auto选项会自动使用游戏默认窗口分辨率。</Description>
     <DefaultValue>window_size_x = 1280,window_size_y = 720</DefaultValue>
     <Option>
       <Text>自动</Text>
@@ -52,9 +52,9 @@
   </Setting>
 
   <Setting xsi:type="DropDown">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>窗口/全屏模式</Name>
-    <Description>按照你的需求，自行选择窗口/全屏/无边框窗口模式。</Description>
+    <Description>按照你的需求，选择窗口/全屏/无边框窗口模式。</Description>
     <DefaultValue>fullscreen = false,borderless = false</DefaultValue>
     <Option>
       <Text>窗口</Text>
@@ -71,32 +71,32 @@
   </Setting>
 
   <Setting xsi:type="DropDown">
-    <Group>图形</Group>
-    <Name>宽高比</Name>
-    <Description>保持宽高比会根据需要添加黑边以保持4:3的原始比例。</Description>
+    <Group>画面</Group>
+    <Name>画面比例</Name>
+    <Description>设置游戏画面的宽高比。{0}选择与你的显示器匹配的比例，否则画面边缘会出现黑边，或画面竖向拉长。{0}此项需要在HD简中拓展项目中进行调整，详见【游戏画面比例】选项。</Description>
     <DefaultValue>aspect_ratio = 0</DefaultValue>
     <Option>
-      <Text>原生(4:3)</Text>
+      <Text>原生 (4:3)</Text>
       <Settings>aspect_ratio = 0</Settings>
     </Option>
     <Option>
-      <Text>拉伸填充</Text>
+      <Text>拉伸画面</Text>
       <Settings>aspect_ratio = 1</Settings>
     </Option>
     <Option>
-      <Text>宽屏(16:9)</Text>
+      <Text>宽屏 (16:9)</Text>
       <Settings>aspect_ratio = 2</Settings>
     </Option>
     <Option>
-      <Text>宽屏(16:10)</Text>
+      <Text>宽屏 (16:10)</Text>
       <Settings>aspect_ratio = 3</Settings>
     </Option>
   </Setting>
 
   <Setting xsi:type="DropDown">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>抗锯齿</Name>
-    <Description>应用 2x/4x/8x/16x MSAA 过滤。减少锯齿边缘并提高图像质量。可能严重影响性能。</Description>
+    <Description>减少锯齿边缘，提高图像质量。{0}考验电脑硬件配置，可能会使游戏卡顿。</Description>
     <DefaultValue>enable_antialiasing = 0</DefaultValue>
     <Option>
       <Text>关闭</Text>
@@ -113,36 +113,36 @@
   </Setting>
 
   <Setting xsi:type="Checkbox">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>各向异性过滤</Name>
-    <Description>对高分辨率纹理应用过滤以产生更清晰的图像。由于内存使用增加可能影响性能。</Description>
+    <Description>给高分辨率贴图加上滤镜，生成更清晰的图像。{0}占用更多系统内存。</Description>
     <DefaultValue>enable_anisotropic = true</DefaultValue>
     <TrueSetting>enable_anisotropic = true</TrueSetting>
     <FalseSetting>enable_anisotropic = false</FalseSetting>
   </Setting>
 
   <Setting xsi:type="Checkbox">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>垂直同步</Name>
-    <Description>将游戏帧率与显示器刷新率同步。可能对性能产生负面影响或破坏60 fps模组。如果出现画面撕裂请开启。*限制速度修正功能！*</Description>
+    <Description>将游戏帧率与你的显示器刷新率同步。如果遇到屏幕撕裂问题，请开启。{0}可能会影响60帧模式。{0}*如果你想使用【游戏变速】功能，请关闭垂直同步。</Description>
     <DefaultValue>enable_vsync = false</DefaultValue>
     <TrueSetting>enable_vsync = true</TrueSetting>
     <FalseSetting>enable_vsync = false</FalseSetting>
   </Setting>
-
+  
   <Setting xsi:type="Checkbox">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>高级光照效果</Name>
-    <Description>为游戏引入实时光照与真实阴影系统。考验CPU硬件配置，如果游戏卡顿，请关闭此项。</Description>
+    <Description>为游戏引入实时光照与真实阴影系统。{0}考验电脑CPU硬件配置，如果游戏卡顿，请关闭此项。</Description>
     <DefaultValue>enable_lighting = false</DefaultValue>
     <TrueSetting>enable_lighting = true</TrueSetting>
     <FalseSetting>enable_lighting = false</FalseSetting>
   </Setting>
 
   <Setting xsi:type="Checkbox">
-    <Group>图形</Group>
+    <Group>画面</Group>
     <Name>NTSC-J 色域模式</Name>
-    <Description>模拟1990年代日本电视机的色域，FF7 最初就是为此设计的。</Description>
+    <Description>选择是否模拟90年代日本电视机的色域（FF7和FF8最初的设计），使画面色彩更丰富。同时影响菜单栏背景色。{0}此项需要在HD简中拓展项目中进行调整，详见【更丰富的色彩】选项。</Description>
     <DefaultValue>enable_ntscj_gamut_mode = false</DefaultValue>
     <TrueSetting>enable_ntscj_gamut_mode = true</TrueSetting>
     <FalseSetting>enable_ntscj_gamut_mode = false</FalseSetting>
@@ -152,18 +152,18 @@
   <Setting xsi:type="DropDown">
     <Group>快捷键</Group>
     <Name>随机遇敌</Name>
-    <Description>开启或关闭随机遇敌。{0}使用方法：在游戏中按键盘 'CTRL+B' 或者 先按手柄 'L3' →再按 'Ο 或 B'</Description>
+    <Description>开启或关闭随机遇敌。{0}使用方法：在游戏中按键盘 'CTRL+B'{0}	或 先按手柄 'L3' 再按 'Ο (B)'</Description>
     <DefaultValue></DefaultValue>
     <Option>
       <Text>详见下方描述</Text>
       <Settings></Settings>
     </Option>
   </Setting>
-
+  
   <Setting xsi:type="DropDown">
     <Group>快捷键</Group>
     <Name>自动普通攻击</Name>
-    <Description>战斗中开启或关闭自动普通攻击。{0}使用方法：在游戏中按键盘 'CTRL+A' 或者 先按手柄 'L3' →再按 '△ 或 Y'</Description>
+    <Description>战斗中开启或关闭自动普通攻击。{0}使用方法：在游戏中按键盘 'CTRL+A'{0}	或 先按手柄 'L3' 再按 '△ (Y)'</Description>
     <DefaultValue></DefaultValue>
     <Option>
       <Text>详见下方描述</Text>
@@ -174,18 +174,18 @@
   <Setting xsi:type="DropDown">
     <Group>快捷键</Group>
     <Name>跳过过场动画</Name>
-    <Description>跳过过场动画。有概率导致游戏卡死，建议仅用于跳过新游戏片头动画。{0}使用方法：在游戏中按键盘 'CTRL+S' 或者 先按手柄 'L3' →再按 '□ 或 X'</Description>
+    <Description>跳过过场动画。有概率导致游戏卡死，建议仅用于跳过新游戏片头动画。{0}使用方法：在游戏中按键盘 'CTRL+S'{0}	或 先按手柄 'L3' 再按 '□ (X)'</Description>
     <DefaultValue></DefaultValue>
     <Option>
       <Text>详见下方描述</Text>
       <Settings></Settings>
     </Option>
   </Setting>
-
+  
   <Setting xsi:type="DropDown">
     <Group>快捷键</Group>
     <Name>软重启</Name>
-    <Description>快速返回到主标题界面，用于重新加载存档。{0}*不要在战斗中软重启，否则重新读档后，战斗会黑屏*{0}使用方法：在游戏中按键盘 'CTRL+R' 或者 先按手柄 'L3' →再按 'Select+Start'</Description>
+    <Description>快速返回到主标题界面，用于重新加载存档。{0}*不要在战斗中软重启，否则重新读档后，战斗会黑屏。{0}使用方法：在游戏中按键盘 'CTRL+R'{0}	或 先按手柄 'L3' 再按 'Select+Start'。</Description>
     <DefaultValue></DefaultValue>
     <Option>
       <Text>详见下方描述</Text>
@@ -195,8 +195,8 @@
 
   <Setting xsi:type="DropDown">
     <Group>快捷键</Group>
-    <Name>速度修正步进</Name>
-    <Description>每次触发时增加或减少速度的量。{0}用法：'CTRL+上/下'或 'L3 键，然后 L1/R1 键' 改变速度，'CTRL+左/右'或 'L3 键，然后 L2/R2 键'切换开关。</Description>
+    <Name>游戏变速递进值</Name>
+    <Description>设置游戏加速/减速的递进值。每次按快捷键时，递进值越大，越能更快到达【最大加速倍数】，或更快减速恢复到【正常速度】。{0}使用方法：按键盘 'CTRL+↑/↓' 或 先按手柄 'L3' 再按 'L1/R1' 进行加速/减速，{0}	键盘'CTRL+←/→' 或 先按手柄 'L3' 再按 'L2/R2' 开启/关闭变速功能。</Description>
     <DefaultValue>speedhack_step = 0.5</DefaultValue>
     <Option>
       <Text>0.5</Text>
@@ -214,8 +214,8 @@
 
   <Setting xsi:type="DropDown">
     <Group>快捷键</Group>
-    <Name>速度修正最大值</Name>
-    <Description>在循环回正常速度前设置的最大速度。</Description>
+    <Name>最大加速倍数</Name>
+    <Description>设置游戏加速能达到的最大倍数。倍数越高，速度越快。{0}*需要关闭【垂直同步】才能使用游戏变速功能。</Description>
     <DefaultValue>speedhack_max = 8.0</DefaultValue>
     <Option>
       <Text>2x</Text>
@@ -242,12 +242,12 @@
       <Settings>speedhack_max = 12.0</Settings>
     </Option>
   </Setting>
-
+  
   <!-- CONTROLS TAB -->
   <Setting xsi:type="Checkbox">
-    <Group>高级</Group>
+    <Group>控制</Group>
     <Name>手柄自由视角控制</Name>
-    <Description>在战斗中和大地图中解锁360°自由视角旋转。仅用于手柄。</Description>
+    <Description>在战斗中和大地图中解锁360°自由视角旋转。仅用于手柄。{0}*如果你使用键盘游玩，请关闭此项，然后打开Cosmos Gaia模组的自定义配置，关闭【大地图自由视角】选项。</Description>
     <DefaultValue>enable_analogue_controls = false</DefaultValue>
     <TrueSetting>enable_analogue_controls = true</TrueSetting>
     <FalseSetting>enable_analogue_controls = false</FalseSetting>
@@ -256,7 +256,7 @@
   <Setting xsi:type="Checkbox">
     <Group>控制</Group>
     <Name>手柄左摇杆自动奔跑</Name>
-    <Description>推动手柄左摇杆，控制的角色会自动以奔跑状态移动。仅用于手柄。</Description>
+    <Description>推动手柄左摇杆，当前控制的角色会自动以奔跑状态移动。仅用于手柄。</Description>
     <DefaultValue>enable_auto_run = false</DefaultValue>
     <TrueSetting>enable_auto_run = true</TrueSetting>
     <FalseSetting>enable_auto_run = false</FalseSetting>
@@ -264,8 +264,8 @@
 
   <Setting xsi:type="Checkbox">
     <Group>控制</Group>
-    <Name>反转水平控制</Name>
-    <Description>启用后在战斗中控制视角时反转水平移动方向。</Description>
+    <Name>水平视角翻转</Name>
+    <Description>推动手柄右摇杆旋转视角时，水平旋转方向与你的摇杆推动方向相反。</Description>
     <DefaultValue>enable_inverted_horizontal_camera_controls = false</DefaultValue>
     <TrueSetting>enable_inverted_horizontal_camera_controls = true</TrueSetting>
     <FalseSetting>enable_inverted_horizontal_camera_controls = false</FalseSetting>
@@ -273,8 +273,8 @@
 
   <Setting xsi:type="Checkbox">
     <Group>控制</Group>
-    <Name>反转垂直控制</Name>
-    <Description>启用后在战斗中控制视角时反转垂直移动方向。</Description>
+    <Name>垂直视角翻转</Name>
+    <Description>推动手柄右摇杆旋转视角时，垂直旋转方向与你的摇杆推动方向相反。</Description>
     <DefaultValue>enable_inverted_vertical_camera_controls = false</DefaultValue>
     <TrueSetting>enable_inverted_vertical_camera_controls = true</TrueSetting>
     <FalseSetting>enable_inverted_vertical_camera_controls = false</FalseSetting>
@@ -283,17 +283,17 @@
   <!-- ADVANCED TAB -->
   <Setting xsi:type="Checkbox">
     <Group>高级</Group>
-    <Name>Steam 兼容性</Name>
-    <Description>启用 Steam 功能(游戏活动、控制器和成就)。需要 Steam 正在运行。</Description>
+    <Name>关联 Steam</Name>
+    <Description>与 FF7 Steam版进行关联，用于解锁游戏成就。</Description>
     <DefaultValue>enable_steam_achievements = false</DefaultValue>
     <TrueSetting>enable_steam_achievements = true</TrueSetting>
     <FalseSetting>enable_steam_achievements = false</FalseSetting>
   </Setting>
-
+  
   <Setting xsi:type="Checkbox">
     <Group>高级</Group>
-    <Name>显示调试信息</Name>
-    <Description>在覆盖层或标题栏中显示有关渲染过程/性能的实时信息。</Description>
+    <Name>游戏内显示调试信息</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示有关渲染过程/性能的实时信息。</Description>
     <DefaultValue>show_stats = false</DefaultValue>
     <TrueSetting>show_stats = true</TrueSetting>
     <FalseSetting>show_stats = false</FalseSetting>
@@ -302,7 +302,7 @@
   <Setting xsi:type="Checkbox">
     <Group>高级</Group>
     <Name>显示驱动版本</Name>
-    <Description>在覆盖层或标题栏中显示当前使用的驱动版本。</Description>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示当前的驱动版本。</Description>
     <DefaultValue>show_version = false</DefaultValue>
     <TrueSetting>show_version = true</TrueSetting>
     <FalseSetting>show_version = false</FalseSetting>
@@ -310,8 +310,8 @@
 
   <Setting xsi:type="Checkbox">
     <Group>高级</Group>
-    <Name>显示帧率(FPS)</Name>
-    <Description>在覆盖层或标题栏中显示当前帧率(FPS)。</Description>
+    <Name>显示帧率</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示游戏实时帧率。</Description>
     <DefaultValue>show_fps = false</DefaultValue>
     <TrueSetting>show_fps = true</TrueSetting>
     <FalseSetting>show_fps = false</FalseSetting>
@@ -319,28 +319,28 @@
 
   <Setting xsi:type="Checkbox">
     <Group>高级</Group>
-    <Name>显示图形 API</Name>
-    <Description>在覆盖层或标题栏中显示当前使用的图形 API(OpenGL/DirectX11)。</Description>
+    <Name>显示图形API版本</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示当前使用的图形API版本(OpenGL/DirectX11)。</Description>
     <DefaultValue>show_renderer_backend = false</DefaultValue>
     <TrueSetting>show_renderer_backend = true</TrueSetting>
     <FalseSetting>show_renderer_backend = false</FalseSetting>
   </Setting>
-
+  
   <Setting xsi:type="DropDown">
     <Group>高级</Group>
-    <Name>内部分辨率缩放</Name>
-    <Description>将640x480内部分辨率乘以以下数值。更高值需要更强大的GPU。更高值可以消除缩放伪影，*标记值为性能与质量的最佳平衡点。</Description>
+    <Name>内部分辨率放大倍数</Name>
+    <Description>将游戏原生分辨率640x480乘以所选的倍数，提高模型精细度。由于FF7天幻中文字库贴图分辨率的上限为2x，所以不建议选择更高的倍数，否则字体将会出现视觉错误。</Description>
     <DefaultValue>internal_resolution_scale = 0</DefaultValue>
     <Option>
-      <Text>自动</Text>
+      <Text>Auto</Text>
       <Settings>internal_resolution_scale = 0</Settings>
     </Option>
     <Option>
-      <Text>1x(可能导致伪影)</Text>
+      <Text>1x (可能导致画面模糊)</Text>
       <Settings>internal_resolution_scale = 1</Settings>
     </Option>
     <Option>
-      <Text>2x</Text>
+      <Text>2x (中文版最佳设置)</Text>
       <Settings>internal_resolution_scale = 2</Settings>
     </Option>
     <Option>

--- a/AppUI/Resources/Languages/StringResources.zh.xaml
+++ b/AppUI/Resources/Languages/StringResources.zh.xaml
@@ -1,42 +1,43 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <!--Main Window Buttons-->
-    <system:String x:Key="Play">启动游戏</system:String>
-    <system:String x:Key="PlayWithMods">启动时使用模组(默认)</system:String>
-    <system:String x:Key="PlayWithNoMods">启动时不使用模组</system:String>
-    <system:String x:Key="PlayWithDebugLog">启动时启用调试日志</system:String>
-    <system:String x:Key="PlayWithVariableDump">启动时启用变量存储</system:String>
+    <system:String x:Key="Play">运行游戏</system:String>
+    <system:String x:Key="PlayWithMods">有模组运行 (默认)</system:String>
+    <system:String x:Key="PlayWithNoMods">无模组运行</system:String>
+    <system:String x:Key="PlayWithMinimalValidation">最小验证运行</system:String>
+    <system:String x:Key="PlayWithDebugLog">带调试日志运行</system:String>
+    <system:String x:Key="PlayWithVariableDump">带变量转储运行</system:String>
 
     <system:String x:Key="Settings">设置</system:String>
-    <system:String x:Key="ChangeColorTheme">更改颜色主题...</system:String>
+    <system:String x:Key="ChangeColorTheme">配色主题...</system:String>
     <system:String x:Key="GeneralSettings">常规设置...</system:String>
     <system:String x:Key="GameDriver">游戏驱动...</system:String>
     <system:String x:Key="GameLauncher">游戏启动器...</system:String>
     <system:String x:Key="Profiles">预设...</system:String>
-    <system:String x:Key="Language">语言...</system:String>
+    <system:String x:Key="Language">界面语言...</system:String>
 
 
     <system:String x:Key="Tools">工具</system:String>
-    <system:String x:Key="CatalogModCreationTool">目录/模组创建工具...</system:String>
-    <system:String x:Key="ChunkTool">区块工具...</system:String>
+    <system:String x:Key="CatalogModCreationTool">Catalog/Mod 创建工具...</system:String>
+    <system:String x:Key="ChunkTool">Chunk 工具...</system:String>
     <system:String x:Key="IROTools">IRO 工具...</system:String>
 
     <system:String x:Key="Help">帮助</system:String>
     <system:String x:Key="HelpOpen">打开帮助文档</system:String>
-    <system:String x:Key="HelpOpenAbout">关于 7th Heaven</system:String>
+    <system:String x:Key="HelpOpenAbout">关于第七天堂</system:String>
 
     <system:String x:Key="MyMods">我的模组</system:String>
-    <system:String x:Key="MyModsTooltip">右键点击“我的模组”标签，可以打开存放模组的文件夹</system:String>
+    <system:String x:Key="MyModsTooltip">右键点击“我的模组”，可以打开存放模组的文件夹</system:String>
 
-    <system:String x:Key="BrowseCatalog">在线模组下载</system:String>
-    <system:String x:Key="BrowseCatalogTooltip">右键单击“在线模组下载”，可以跳转到在线模组目录订阅设置</system:String>
+    <system:String x:Key="BrowseCatalog">在线模组目录</system:String>
+    <system:String x:Key="BrowseCatalogTooltip">右键点击“在线模组目录”，可以跳转到在线模组目录设置（中国大陆网络需要VPN）</system:String>
 
-    <system:String x:Key="SearchHint">在此输入搜索关键词...</system:String>
-    <system:String x:Key="FiltersTooltip">点击选择要筛选的类别和标签</system:String>
+    <system:String x:Key="SearchHint">输入搜索关键词 ...</system:String>
+    <system:String x:Key="FiltersTooltip">点击展开，可以自定义选择过滤类型</system:String>
 
-    <system:String x:Key="StatusBarTooltip">点击查看应用程序日志</system:String>
+    <system:String x:Key="StatusBarTooltip">点击查看软件日志</system:String>
 
     
     <!--Mod Info Panel-->
@@ -50,9 +51,9 @@
     <system:String x:Key="ClickHere">点击此处</system:String>
     <system:String x:Key="None">无</system:String>
 
-    <system:String x:Key="AutoUpdateInstall">自动更新/安装</system:String>
+    <system:String x:Key="AutoUpdateInstall">自动升级/安装</system:String>
     <system:String x:Key="Ignore">忽略</system:String>
-    <system:String x:Key="Notify">通知</system:String>
+    <system:String x:Key="Notify">提醒</system:String>
 
     <system:String x:Key="DescriptionLabel">描述：</system:String>
     <system:String x:Key="LinkLabel">发布链接:</system:String>
@@ -60,20 +61,20 @@
     <system:String x:Key="ReleaseNotesLabel">更新说明：</system:String>
     <system:String x:Key="DonationLinkLabel">捐赠:</system:String>
 
-    <system:String x:Key="NoPreviewImage">无预览图片</system:String>
+    <system:String x:Key="NoPreviewImage">无预览图</system:String>
 
     
     <!-- Browse Catalog Tab -->
     <system:String x:Key="Name">名称</system:String>
     <system:String x:Key="Author">作者</system:String>
-    <system:String x:Key="Released">更新时间</system:String>
-    <system:String x:Key="Category">类别</system:String>
+    <system:String x:Key="Released">更新日期</system:String>
+    <system:String x:Key="Category">类型</system:String>
     <system:String x:Key="Size">大小</system:String>
     <system:String x:Key="Inst">已安装</system:String>
 
 
-    <system:String x:Key="RefreshCatalogTooltip">强制更新所有订阅并刷新目录</system:String>
-    <system:String x:Key="DownloadModTooltip">下载选定模组</system:String>
+    <system:String x:Key="RefreshCatalogTooltip">强制更新所有已订阅的模组，然后刷新列表</system:String>
+    <system:String x:Key="DownloadModTooltip">下载选中的模组</system:String>
     <system:String x:Key="ResetColumnsTooltip">重置排序</system:String>
 
     <system:String x:Key="Item">项目</system:String>
@@ -81,21 +82,21 @@
     <system:String x:Key="Speed">下载速度</system:String>
     <system:String x:Key="TimeLeft">剩余时间</system:String>
 
-    <system:String x:Key="CancelDownloadTooltip">取消选定下载</system:String>
+    <system:String x:Key="CancelDownloadTooltip">取消选中的下载</system:String>
 
     
     <!--My Mods Tab-->
-    <system:String x:Key="Active">已激活</system:String>
+    <system:String x:Key="Active">开启状态</system:String>
 
     <system:String x:Key="ImportModTooltip">导入模组</system:String>
-    <system:String x:Key="MoveUpTooltip">左键点击上移/右键点击移至顶部</system:String>
-    <system:String x:Key="MoveDownTooltip">左键点击下移/右键点击移至底部</system:String>
+    <system:String x:Key="MoveUpTooltip">左键点击向上移动/右键点击移动到最上方</system:String>
+    <system:String x:Key="MoveDownTooltip">左键点击向上移动/右键点击移动到末尾</system:String>
     <system:String x:Key="AutoSortTooltip">按照模组名称及兼容规则，自动排序</system:String>
-    <system:String x:Key="ConfigureModTooltip">配置模组</system:String>
-    <system:String x:Key="ActivateAllTooltip">激活所有模组</system:String>
-    <system:String x:Key="DeactivateAllTooltip">停用所有模组</system:String>
-    <system:String x:Key="RefreshListTooltip">刷新列表</system:String>
-    <system:String x:Key="UninstallModTooltip">卸载模组</system:String>
+    <system:String x:Key="ConfigureModTooltip">修改所选模组的设置</system:String>
+    <system:String x:Key="ActivateAllTooltip">开启所有模组</system:String>
+    <system:String x:Key="DeactivateAllTooltip">禁用所有模组</system:String>
+    <system:String x:Key="RefreshListTooltip">刷新列表，自动排序</system:String>
+    <system:String x:Key="UninstallModTooltip">删除模组</system:String>
     
     
     <!--Generic MessageBox Buttons-->
@@ -104,312 +105,318 @@
     <system:String x:Key="Close">关闭</system:String>
     <system:String x:Key="Yes">是</system:String>
     <system:String x:Key="No">否</system:String>
-    <system:String x:Key="Off">关闭</system:String>
+    <system:String x:Key="Off">禁用</system:String>
     <system:String x:Key="On">开启</system:String>
-    <system:String x:Key="ResetDefaults">重置为默认值</system:String>
+    <system:String x:Key="ResetDefaults">还原默认</system:String>
     <system:String x:Key="Save">保存</system:String>
     <system:String x:Key="Load">加载</system:String>
     <system:String x:Key="Go">开始</system:String>
 
 
     <!--Window Titles-->
-    <system:String x:Key="GameLauncherWindowTitle">正在启动游戏</system:String>
-    <system:String x:Key="CatalogCreationWindowTitle">目录和模组创建工具</system:String>
+    <system:String x:Key="GameLauncherWindowTitle">正在启动游戏……</system:String>
+    <system:String x:Key="CatalogCreationWindowTitle">模组与目录创建工具</system:String>
     <system:String x:Key="GameDriverWindowTitle">配置游戏驱动设置</system:String>
-    <system:String x:Key="UnexpectedErrorWindowTitle">7th Heaven - 意外错误!</system:String>
-    <system:String x:Key="AllowModToRun">允许运行此模组?</system:String>
+    <system:String x:Key="UnexpectedErrorWindowTitle">第七天堂 - 未知的错误！</system:String>
+    <system:String x:Key="AllowModToRun">允许加载模组吗？</system:String>
     <system:String x:Key="Warning">警告</system:String>
-    <system:String x:Key="Requirements">需求</system:String>
-    <system:String x:Key="ExternalDownload">外部下载?</system:String>
+    <system:String x:Key="Requirements">必须的要求</system:String>
+    <system:String x:Key="ExternalDownload">从外部下载吗？</system:String>
     <system:String x:Key="MissingPath">路径缺失</system:String>
     <system:String x:Key="ExtractComplete">提取完成</system:String>
     <system:String x:Key="InsertDisc">插入光盘</system:String>
-    <system:String x:Key="MissingRequiredInput">缺少必要输入</system:String>
+    <system:String x:Key="MissingRequiredInput">缺少必要的输入</system:String>
     <system:String x:Key="IROToolsWindowTitle">IRO 工具</system:String>
-    <system:String x:Key="ChunkToolWindowTitle">区块工具</system:String>
-    <system:String x:Key="ManageProfiles">管理预设配置文件</system:String>
-    <system:String x:Key="SetLanguageWindowTitle">设置语言</system:String>
+    <system:String x:Key="ChunkToolWindowTitle">Chunk 工具</system:String>
+    <system:String x:Key="ManageProfiles">管理预设文件</system:String>
+    <system:String x:Key="SetLanguageWindowTitle">选择语言</system:String>
 
 
 
 
 
     <!--Allow Mod To Run Window-->
-    <system:String x:Key="NoDontActivateThisMod">不，不要激活此模组</system:String>
-    <system:String x:Key="YesActivateThisMod">是，激活此模组</system:String>
-    <system:String x:Key="DontAskAgainForAnyMods">不再为任何模组询问我</system:String>
+    <system:String x:Key="NoDontActivateThisMod">不，禁用这个模组</system:String>
+    <system:String x:Key="YesActivateThisMod">好，开启这个模组</system:String>
+    <system:String x:Key="DontAskAgainForAnyMods">以后不要再询问这个问题</system:String>
     
     <!--Game Launcher Settings Window-->
-    <system:String x:Key="OptionsHeader" xml:space="preserve">选项</system:String>
-    <system:String x:Key="AutoMountDisc">自动挂载游戏光盘</system:String>
-    <system:String x:Key="AutoMountDiscTooltip">启动游戏时自动挂载游戏光盘 ISO。仅限 Windows 8及以上系统。如果使用 Windows 7或更早系统，需要手动插入光盘或挂载 ISO。</system:String>
+    <system:String x:Key="OptionsHeader" xml:space="preserve"> 设置 </system:String>
+    <system:String x:Key="AutoMountDisc">自动加载虚拟光驱</system:String>
+    <system:String x:Key="AutoMountDiscTooltip">在启动游戏时自动加载软件附带的.ISO虚拟光驱，仅限Windows 8/10/11系统。如果你使用Windows 7甚至更旧的系统，则需要自己手动加载.ISO虚拟光驱，或插入游戏光盘。</system:String>
 
-    <system:String x:Key="AutoDismountDisc">自动卸载游戏光盘</system:String>
-    <system:String x:Key="AutoDismountDiscTooltip">游戏关闭时自动卸载游戏光盘 ISO。仅限 Windows 8及以上系统。如果使用 Windows 7或更早系统，需要手动弹出光盘或卸载 ISO。</system:String>
+    <system:String x:Key="AutoDismountDisc">自动卸载虚拟光驱</system:String>
+    <system:String x:Key="AutoDismountDiscTooltip">在退出游戏时自动卸载软件附带的.ISO虚拟光驱，仅限Windows 8/10/11系统。如果你使用Windows 7甚至更旧的系统，则需要自己手动弹出.ISO虚拟光驱或游戏光盘。</system:String>
 
-    <system:String x:Key="AutoUpdatePath">自动更新光盘路径</system:String>
-    <system:String x:Key="AutoUpdatePathTooltip">检测光盘是否更改了驱动器号并自动更新游戏指向新位置。</system:String>
+    <system:String x:Key="AutoUpdatePath">自动更新光驱路径</system:String>
+    <system:String x:Key="AutoUpdatePathTooltip">自动检测光盘是否已更改驱动器号，并自动更新游戏所读取的路径。</system:String>
 
     <system:String x:Key="ShowGameLauncher">启动游戏时显示加载窗口</system:String>
-    <system:String x:Key="ShowGameLauncherTooltip">启动 FF7 时显示游戏启动器窗口，查看启动过程的详细输出。</system:String>
+    <system:String x:Key="ShowGameLauncherTooltip">通过窗口显示FF7启动过程中的详细日志。如果游戏无法启动，则需要通过这个窗口来查看报错原因，建议开启。</system:String>
 
-    <system:String x:Key="ControlsLabel">按键设置：</system:String>
+    <system:String x:Key="ControlsLabel">按键设置:</system:String>
 
-    <system:String x:Key="SaveControlsTooltip">保存当前游戏内按键配置。</system:String>
-    <system:String x:Key="DeleteControlsTooltip">删除选定的自定义按键配置。</system:String>
+    <system:String x:Key="SaveControlsTooltip">保存你当前的游戏内按键设置。</system:String>
+    <system:String x:Key="DeleteControlsTooltip">删除所选的按键预设。</system:String>
     
-    <system:String x:Key="CompatibilityHeader" xml:space="preserve">兼容性</system:String>
-    <system:String x:Key="HighDpiScalingFix">高 DPI 缩放修复</system:String>
-    <system:String x:Key="HighDpiScalingFixTooltip">可修复游戏画面被裁剪和/或未居中的问题。用于高 DPI 显示器。或者，将 Windows 显示设置改为100%缩放。</system:String>
+    <system:String x:Key="CompatibilityHeader" xml:space="preserve"> 兼容性 </system:String>
+    <system:String x:Key="HighDpiScalingFix">高分辨率缩放修复</system:String>
+    <system:String x:Key="HighDpiScalingFixTooltip">可以修复游戏画面显示不全/无法居中。或者将你的Windows显示设置更改为100%缩放。</system:String>
 
-    <system:String x:Key="ReunionDriverFix">Reunion 驱动修复</system:String>
-    <system:String x:Key="ReunionDriverFixTooltip">在游戏启动时临时将 ddraw.dll 重命名为 Reunion.dll.bak，然后立即改回。不影响 7H 外 Reunion 的可玩性。</system:String>
+    <system:String x:Key="ReunionDriverFix">Reunion驱动修复</system:String>
+    <system:String x:Key="ReunionDriverFixTooltip">在游戏启动时暂时将draw.dll重命名为Reunion.dll.bak，然后立即恢复。不影响Reunion在第七天堂之外的可玩性。</system:String>
 
 
-    <system:String x:Key="ImportMoviesHeader" xml:space="preserve">从光盘导入过场动画</system:String>
+    <system:String x:Key="ImportMoviesHeader" xml:space="preserve"> 从游戏光盘导入过场动画 </system:String>
     <system:String x:Key="Import">导入</system:String>
-    <system:String x:Key="ImportTooltip">从光盘导入缺失的过场动画文件。</system:String>
+    <system:String x:Key="ImportTooltip">提取游戏光盘里的过场动画文件，修复游戏丢失过场动画的问题。</system:String>
 
 
-    <system:String x:Key="AudioDeviceHeader" xml:space="preserve">音频输出设备</system:String>
-    <system:String x:Key="SoundDeviceLabel">音频设备：</system:String>
-    <system:String x:Key="SoundDeviceTooltip">为 FF7 选择输出音频设备。</system:String>
+    <system:String x:Key="AudioDeviceHeader" xml:space="preserve"> 音频输出设备 </system:String>
+    <system:String x:Key="SoundDeviceLabel">声音设备:</system:String>
+    <system:String x:Key="SoundDeviceTooltip">为游戏选择一个声音输出设备。</system:String>
 
-    <system:String x:Key="TestSoundTooltip">测试选定的声音设备和音乐/音效音量。测试声音由 Enrico Deiana 提供。</system:String>
-    <system:String x:Key="TestLeftSoundTooltip">测试选定的声音设备和音乐/音效音量(左声道)。测试声音由 Enrico Deiana 提供。</system:String>
-    <system:String x:Key="TestRightSoundTooltip">测试选定的声音设备和音乐/音效音量(右声道)。测试声音由 Enrico Deiana 提供。</system:String>
+    <system:String x:Key="TestSoundTooltip">测试所选择的声音设备与音乐/音效的音量（由 Enrico Deiana 提供的技术）。</system:String>
+    <system:String x:Key="TestLeftSoundTooltip">试听左声道（由 Enrico Deiana 提供的技术）。</system:String>
+    <system:String x:Key="TestRightSoundTooltip">试听右声道（由 Enrico Deiana 提供的技术）。</system:String>
 
-    <system:String x:Key="MidiDeviceLabel">MIDI 设备：</system:String>
-    <system:String x:Key="MidiDeviceTooltip">为 FF7 选择输出 MIDI 设备。</system:String>
+    <system:String x:Key="MidiDeviceLabel">MIDI 设备:</system:String>
+    <system:String x:Key="MidiDataLabel">MIDI 数据:</system:String>
+    <system:String x:Key="MidiDeviceTooltip">为游戏选择一个MIDI输出设备。</system:String>
 
-    <system:String x:Key="SFXVolumeLabel">SFX 音量：</system:String>
-    <system:String x:Key="SFXVolumeTooltip">设置游戏内 SFX 音量。</system:String>
+    <system:String x:Key="SFXVolumeLabel">音效音量:</system:String>
+    <system:String x:Key="SFXVolumeTooltip">设置游戏内音效的音量。</system:String>
 
-    <system:String x:Key="MusicVolumeLabel">音乐音量：</system:String>
-    <system:String x:Key="MusicVolumeTooltip">设置游戏内音乐音量。</system:String>
+    <system:String x:Key="MusicVolumeLabel">音乐音量:</system:String>
+    <system:String x:Key="MusicVolumeTooltip">设置游戏内音乐的音量。</system:String>
 
-    <system:String x:Key="LogVolumeControl">对数音量控制</system:String>
-    <system:String x:Key="LogVolumeControlTooltip">如果感觉音量变化不平稳，请取消勾选此选项。</system:String>
+    <system:String x:Key="VoiceVolumeLabel">语音音量:</system:String>
+    <system:String x:Key="VoiceVolumeTooltip">设置游戏内语音的音量（需要语音模组）。</system:String>
 
-    <system:String x:Key="ReverseSpeakers">反转扬声器</system:String>
-    <system:String x:Key="ReverseSpeakersTooltip">勾选时交换左右声道。</system:String>
+    <system:String x:Key="AmbientVolumeLabel">环境效果音音量:</system:String>
+    <system:String x:Key="AmbientVolumeTooltip">设置游戏内环境效果音的音量（需要环境效果音模组）。</system:String>
+
+    <system:String x:Key="MovieVolumeLabel">过场动画音量:</system:String>
+    <system:String x:Key="MovieVolumeTooltip">设置游戏内过场动画的音量。</system:String>
+
+    <system:String x:Key="LogVolumeControl">数字音量控制</system:String>
+    <system:String x:Key="LogVolumeControlTooltip">如果你觉得音量变化不平稳，请关闭此选项。</system:String>
+
+    <system:String x:Key="ReverseSpeakers">左声道/右声道反转</system:String>
+    <system:String x:Key="ReverseSpeakersTooltip">将左声道/右声道反转。</system:String>
 
 
-    <system:String x:Key="GraphicsDriverHeader" xml:space="preserve">图形驱动选项</system:String>
-    <system:String x:Key="RendererLabel">渲染器：</system:String>
-    <system:String x:Key="RendererTooltip">选择用于渲染 FF7 的图形驱动。模组仅在设置为"自定义 7H 游戏驱动"时才能工作。</system:String>
+    <system:String x:Key="GraphicsDriverHeader" xml:space="preserve"> 图形驱动选项</system:String>
+    <system:String x:Key="RendererLabel">渲染器:</system:String>
+    <system:String x:Key="RendererTooltip">选择一个图形驱动程序，用于渲染FF7。mod只能在设置为“自定义第七天堂游戏驱动”时生效。</system:String>
 
-    <system:String x:Key="QuarterScreen">四分之一屏幕</system:String>
-    <system:String x:Key="QuarterScreenTooltip">以窗口模式启动游戏(四分之一屏幕)。仅当设置为"软件渲染器"或 "Direct3D 硬件加速"时适用。</system:String>
+    <system:String x:Key="QuarterScreen">四分之一屏</system:String>
+    <system:String x:Key="QuarterScreenTooltip">启动游戏窗口（四分之一屏幕大小）。仅在设置为“软件渲染器”或“Direct3D硬件加速”时生效。</system:String>
 
     <system:String x:Key="FullScreen">全屏</system:String>
-    <system:String x:Key="FullScreenTooltip">以全屏模式启动游戏。仅当设置为"软件渲染器"或 "Direct3D 硬件加速"时适用。</system:String>
+    <system:String x:Key="FullScreenTooltip">全屏启动游戏。仅在设置为“软件渲染器”或“Direct3D硬件加速”时生效。</system:String>
 
-    <system:String x:Key="HardwareGraphicsTooltip">设置硬件加速选项。仅当设置为 "Direct3D 硬件加速"时适用。</system:String>
+    <system:String x:Key="HardwareGraphicsTooltip">设置用于硬件加速的选项。仅在设置为“Direct3D硬件加速”时生效。</system:String>
 
 
-    <system:String x:Key="ProgramsToRunHeader" xml:space="preserve">在 FF7 之前运行的程序</system:String>
-    <system:String x:Key="ProgramNameHint">输入要运行的程序的完整路径</system:String>
+    <system:String x:Key="ProgramsToRunHeader" xml:space="preserve"> 启动游戏时优先运行的程序: </system:String>
+    <system:String x:Key="ProgramNameHint">输入程序的完整路径</system:String>
     <system:String x:Key="ProgramArgsHint">输入程序参数</system:String>
 
-    <system:String x:Key="AddProgramTooltip">新增在 FF7 启动前运行的程序。</system:String>
-    <system:String x:Key="RemoveProgramTooltip">移除选定程序。</system:String>
-    <system:String x:Key="EditProgramTooltip">编辑选定程序和参数。</system:String>
-    <system:String x:Key="MoveProgramUpTooltip">将选定程序在列表中上移。右键点击移至顶部。</system:String>
-    <system:String x:Key="MoveProgramDownTooltip">将选定程序在列表中下移。右键点击移至底部。</system:String>
+    <system:String x:Key="AddProgramTooltip">设置优先运行的程序，在启动游戏时，先运行程序，再运行FF7。</system:String>
+    <system:String x:Key="RemoveProgramTooltip">移除所选的程序。</system:String>
+    <system:String x:Key="EditProgramTooltip">编辑所选程序的参数。</system:String>
+    <system:String x:Key="MoveProgramUpTooltip">左键点击向上移动/右键点击移动到最上方。</system:String>
+    <system:String x:Key="MoveProgramDownTooltip">左键点击向下移动/右键点击移动到末尾。</system:String>
     <system:String x:Key="BrowseProgramTooltip">浏览要运行的程序</system:String>
 
-    <system:String x:Key="ResetLauncherDefaultsTooltip">将游戏启动器设置重置为默认值。</system:String>
+    <system:String x:Key="ResetLauncherDefaultsTooltip">将页面内所有选项重置到默认状态。</system:String>
     
     <!--Catalog Creation Window-->
-    <system:String x:Key="CreateMod">创建模组</system:String>
-    <system:String x:Key="CreateCatalog">创建目录</system:String>
-    <system:String x:Key="MegaLinkGenerator">Mega 链接生成器</system:String>
+    <system:String x:Key="CreateMod">创建模组 Mod</system:String>
+    <system:String x:Key="CreateCatalog">创建目录 Catalog</system:String>
+    <system:String x:Key="MegaLinkGenerator">Mega网盘链接生成器</system:String>
 
     
     <!--Chunk Tool Window-->
-    <system:String x:Key="SelectFlevelLabel">选择 FLEVEL：</system:String>
-    <system:String x:Key="OutputFolderLabel">输出文件夹：</system:String>
+    <system:String x:Key="SelectFlevelLabel">选择 FLEVEL:</system:String>
+    <system:String x:Key="OutputFolderLabel">输出文件夹:</system:String>
 
-    <system:String x:Key="SectionHeader" xml:space="preserve">>区块#</system:String>
-    <system:String x:Key="Section1">区块1 场景脚本对话</system:String>
-    <system:String x:Key="Section2">区块2 摄像机矩阵</system:String>
-    <system:String x:Key="Section3">区块3 模型加载器</system:String>
-    <system:String x:Key="Section4">区块4 调色板</system:String>
-    <system:String x:Key="Section5">区块5 行走网格</system:String>
-    <system:String x:Key="Section6">区块6 瓦片地图(未使用)</system:String>
-    <system:String x:Key="Section7">区块7 遭遇战</system:String>
-    <system:String x:Key="Section8">区块8 触发器</system:String>
-    <system:String x:Key="Section9">区块9 背景</system:String>
+    <system:String x:Key="SectionHeader" xml:space="preserve"> 区段 # </system:String>
+    <system:String x:Key="Section1">区段 1 场景对话 Field Script Dialog</system:String>
+    <system:String x:Key="Section2">区段 2 镜头矩阵 Camera Matrix</system:String>
+    <system:String x:Key="Section3">区段 3 模型加载器 Model Loader</system:String>
+    <system:String x:Key="Section4">区段 4 调色板 Palette</system:String>
+    <system:String x:Key="Section5">区段 5 可行走网格 Walkmesh</system:String>
+    <system:String x:Key="Section6">区段 6 瓦片地图 TileMap (Unused)</system:String>
+    <system:String x:Key="Section7">区段 7 随机战斗Encounter</system:String>
+    <system:String x:Key="Section8">区段 8 触发器 Triggers</system:String>
+    <system:String x:Key="Section9">区段 9 背景 Background</system:String>
 
     <system:String x:Key="Extract">提取</system:String>
 
 
     <!--Configure Mod Window-->
-    <system:String x:Key="ConfigureHeader" xml:space="preserve">配置</system:String>
-    <system:String x:Key="Preview">预览</system:String>
+    <system:String x:Key="ConfigureHeader" xml:space="preserve"> 自定义配置 </system:String>
+    <system:String x:Key="Preview">试听</system:String>
     <system:String x:Key="Stop">停止</system:String>
-    <system:String x:Key="ResetToModDefaults">重置为模组默认值</system:String>
+    <system:String x:Key="ResetToModDefaults">还原到初始状态</system:String>
     
     <!--MainWindow.xaml.cs Strings-->
-    <system:String x:Key="AreYouSureYouWantToPlayDebugWarning" xml:space="preserve">您确定要以这种模式运行 FF7 吗？以这种方式运行 FF7 可能导致极度缓慢并占用大量磁盘空间。
+    <system:String x:Key="AreYouSureYouWantToPlayDebugWarning" xml:space="preserve">你确定要在这个模式下玩FF7吗？可能会导致极度缓慢并占用大量硬盘空间。
 
-您应该仅在排查单个活动模组的问题时使用此选项，以便您可以排查问题并向模组作者和/或 7H 开发人员提交错误报告。</system:String>
+这个模式仅用于排查单个模组的故障，以便向模组作者/第七天堂开发者提交错误报告。</system:String>
 
-    <system:String x:Key="AreYouSureYouWantToExitPendingDownloads">您确定要退出吗？您有下载任务正在进行中。</system:String>
+    <system:String x:Key="AreYouSureYouWantToExitPendingDownloads">下载尚未完成，确定退出吗？</system:String>
     <system:String x:Key="ConfirmExit">确认退出</system:String>
     <system:String x:Key="Exit">退出</system:String>
 
-    <system:String x:Key="CannotExitWhileImporting">您的模组当前正在导入中，关闭 7th Heaven 可能导致严重损坏状态。请等待此过程完成后再试。</system:String>
+    <system:String x:Key="CannotExitWhileImporting">模组导入过程中不要退出！否则数据会损坏。</system:String>
 
     <!--MainWindowViewModel Strings-->
-    <system:String x:Key="StartedClickHereToViewAppLog">已启动 - 点击此处查看应用程序日志。</system:String>
-    <system:String x:Key="HintLabel">提示：</system:String>
-    <system:String x:Key="CheckingForUpdates">正在检查应用程序更新...</system:String>
+    <system:String x:Key="StartedClickHereToViewAppLog">已启动 - 点击这里查看软件日志。</system:String>
+    <system:String x:Key="HintLabel">提示:</system:String>
+    <system:String x:Key="CheckingForUpdates">正在检查软件更新 ...</system:String>
     <system:String x:Key="SelectAll">全选</system:String>
     <system:String x:Key="Unknown">未知</system:String>
 
-    <system:String x:Key="UpdateAvailable">有可用更新</system:String>
+    <system:String x:Key="UpdateAvailable">有新版本</system:String>
     <system:String x:Key="UpdateDownloading">正在下载更新</system:String>
 
     <system:String x:Key="NoUpdates">无更新</system:String>
-    <system:String x:Key="UpdatesIgnored">更新已忽略</system:String>
+    <system:String x:Key="UpdatesIgnored">忽略更新</system:String>
     <system:String x:Key="AutoUpdate">自动更新</system:String>
 
-    <system:String x:Key="FollowingErrorsFoundInConfiguration">在您的配置中发现以下错误：</system:String>
-    <system:String x:Key="ErrorsFoundInGeneralSettingsViewAppLog">在常规设置中发现错误。查看 app.log 获取错误详情。</system:String>
+    <system:String x:Key="FollowingErrorsFoundInConfiguration">在你的设置中存在以下错误:</system:String>
+    <system:String x:Key="ErrorsFoundInGeneralSettingsViewAppLog">游戏路径设置存在错误，请打开软件日志，查看报错原因。</system:String>
 
-    <system:String x:Key="AppUpdateIsAvailableMessage" xml:space="preserve">{0}有可用更新
-点击"是"下载新安装程序并开始更新过程。
-        
-{1} 更新说明：{2}
-    </system:String>
-    <system:String x:Key="NewVersionAvailable">有新版本可用！</system:String>
+    <system:String x:Key="AppUpdateIsAvailableMessage" xml:space="preserve">{0} 有新版本 \n 点击“是”进行更新 \n\n{1} 更新日志:</system:String>
+    <system:String x:Key="NewVersionAvailable">有新版本！</system:String>
 
-    <system:String x:Key="ThisModContainsDataThatCouldHarm" xml:space="preserve">此模组 '{0}' 包含可能损害您计算机的数据。您应该只激活您信任的模组。
-        
-您仍然想要激活此模组吗？</system:String>
+    <system:String x:Key="ThisModContainsDataThatCouldHarm" xml:space="preserve">'{0}' 会为 EXE 注入代码，可能会有病毒。为了保障电脑安全，请确保你要开启的模组来自可信任的作者。例如直接从“在线模组目录”下载的模组。
 
-    <system:String x:Key="CannotOpenHelp">无法打开帮助 - 未找到 Resources/Help/index.html 文件</system:String>
+确定开启此模组？</system:String>
 
-    <system:String x:Key="SubscriptionIsAlreadyAdded">订阅 {0} 已新增。</system:String>
-    <system:String x:Key="AddedToSubscriptions">新增 {0} 到订阅。</system:String>
-    <system:String x:Key="IrosLinkMayBeFormatedIncorrectly">iros://链接 {0} 可能格式不正确。无法新增到订阅。</system:String>
+    <system:String x:Key="CannotOpenHelp">无法打开帮助文档 - 软件根目录下 Resources/Help/index.html 文件丢失</system:String>
 
-    <system:String x:Key="FailedToSetBackgroundImageFromTheme">从主题设置背景图片失败。</system:String>
+    <system:String x:Key="SubscriptionIsAlreadyAdded">模组 {0} 已经存在。</system:String>
+    <system:String x:Key="AddedToSubscriptions">将在线模组 {0} 添加到“我的模组”中。</system:String>
+    <system:String x:Key="IrosLinkMayBeFormatedIncorrectly">iros:// link {0} 链接不正确，无法添加。</system:String>
 
+    <system:String x:Key="FailedToSetBackgroundImageFromTheme">背景图片导入失败。</system:String>
 
 
 
     <!--MyModsViewModel Strings-->
     
-    <system:String x:Key="ModRequiresModsIsMissingWarning" xml:space="preserve">此模组需要以下模组也处于激活状态，但无法找到它们：
+    <system:String x:Key="ModRequiresModsIsMissingWarning" xml:space="preserve">这个模组需要搭配下列模组:
 {0}
-除非您安装它们，否则可能无法正常工作。</system:String>
+如果你没有安装并开启这些模组，则可能无法正常运行。</system:String>
 
-    <system:String x:Key="UnsupportedModVersionsWarning" xml:space="preserve">此模组需要以下模组，但您没有支持的版本：
+    <system:String x:Key="UnsupportedModVersionsWarning" xml:space="preserve">这个模组需要搭配下列模组:
 {0}
-您可能需要更新这些模组。</system:String>
+但版本已过时，你需要更新这些模组。</system:String>
 
-    <system:String x:Key="ThisModRequiresYouActivateFollowingMods" xml:space="preserve">此模组要求您激活以下模组：
+    <system:String x:Key="ThisModRequiresYouActivateFollowingMods" xml:space="preserve">这个模组需要搭配下列模组:
 {0}
-它们将自动开启。</system:String>
+这些模组将会自动开启。</system:String>
 
-    <system:String x:Key="ModRequiresYouDeactivateTheFollowingMods" xml:space="preserve">此模组要求您停用以下模组：
+    <system:String x:Key="ModRequiresYouDeactivateTheFollowingMods" xml:space="preserve">这个模组*不兼容*下列模组:
 {0}
-它们将自动关闭。</system:String>
+这些模组将会自动禁用。</system:String>
 
 
-    <system:String x:Key="CannotActivateModBecauseItIsIncompatibleWithOtherMod" xml:space="preserve">您无法激活此模组，因为它与 {0} 不兼容。您需要先停用 {0} 才能启用此模组。</system:String>
+    <system:String x:Key="CannotActivateModBecauseItIsIncompatibleWithOtherMod" xml:space="preserve">无法开启此模组，它与 {0} 不兼容。你需要先将 {0} 禁用，才能开启此模组。</system:String>
 
-    <system:String x:Key="CannotActivateModBecauseDependentIsIncompatible" xml:space="preserve">您无法激活此模组，因为它需要 {0} 处于激活状态，但 {0} 与 {1} 不兼容。您需要先停用 {1} 才能启用此模组。</system:String>
+    <system:String x:Key="CannotActivateModBecauseDependentIsIncompatible" xml:space="preserve">无法开启此模组，它需要与 {0} 搭配使用，但 {0} 与 {1} 不兼容。你需要先将 {1} 禁用，才能开启此模组。</system:String>
 
     <system:String x:Key="MissingRequirements">缺失必要内容</system:String>
     <system:String x:Key="UnsupportedVersion">不支持的版本</system:String>
-    <system:String x:Key="MissingRequiredActiveMods">缺少必要的激活模组</system:String>
-    <system:String x:Key="DeactivateModsWarning">停用模组警告</system:String>
-    <system:String x:Key="Uninstalled">已卸载</system:String>
+    <system:String x:Key="MissingRequiredActiveMods">缺失需要开启的模组</system:String>
+    <system:String x:Key="DeactivateModsWarning">禁用模组警告</system:String>
+    <system:String x:Key="Uninstalled">未安装</system:String>
 
-    <system:String x:Key="CanNotReOrderModItHasBeenRemoved">无法重新排序模组。似乎 {0} 已从文件系统中删除。</system:String>
-    <system:String x:Key="CanNotConfigureModItHasBeenRemoved">无法配置模组。似乎 {0} 已从文件系统中删除。</system:String>
-    <system:String x:Key="CanNotConfigureModFailedToReadModXml">配置模组 {0} 失败 - 读取 mod.xml 失败</system:String>
+    <system:String x:Key="CanNotReOrderModItHasBeenRemoved">无法添加 {0}，它不在存放模组的文件夹里。</system:String>
+    <system:String x:Key="CanNotConfigureModItHasBeenRemoved">无法配置 {0}，它不在存放模组的文件夹里。</system:String>
+    <system:String x:Key="CanNotConfigureModFailedToReadModXml">无法配置 {0}， - 无法读取它的 mod.xml</system:String>
 
-    <system:String x:Key="NoOptions">无选项</system:String>
-    <system:String x:Key="ThereAreNoOptionsToConfigureForThisMod">此模组没有可配置的选项。</system:String>
+    <system:String x:Key="NoOptions">无可选项</system:String>
+    <system:String x:Key="ThereAreNoOptionsToConfigureForThisMod">这个模组没有可选项。</system:String>
 
-    <system:String x:Key="NewVersionOfModAvailable">{0} 有新版本可用</system:String>
+    <system:String x:Key="NewVersionOfModAvailable">{0} 有新版本</system:String>
 
 
     <!--CatalogViewModel Strings-->
 
-    <system:String x:Key="ThisModAlsoRequiresYouDownloadTheFollowing" xml:space="preserve">此模组还需要搭配下列模组:
+    <system:String x:Key="ThisModAlsoRequiresYouDownloadTheFollowing" xml:space="preserve">这个模组需要搭配下列模组:
 {0}
-下载并安装它们吗？</system:String>
+确定一起下载安装吗？</system:String>
 
-    <system:String x:Key="ThisModRequiresTheFollowingButCouldNotBeFoundInCatalog" xml:space="preserve">此模组还需要搭配下列模组:
+    <system:String x:Key="ThisModRequiresTheFollowingButCouldNotBeFoundInCatalog" xml:space="preserve">这个模组需要搭配下列模组:
 {0}
 并未在存放模组的文件夹检测到这些模组。</system:String>
 
-    <system:String x:Key="PauseResumeSelectedDownload">暂停/继续选定下载</system:String>
-    <system:String x:Key="PauseSelectedDownload">暂停选定下载</system:String>
-    <system:String x:Key="ResumeSelectedDownload">继续选定下载</system:String>
+    <system:String x:Key="PauseResumeSelectedDownload">暂停/恢复 所选的下载</system:String>
+    <system:String x:Key="PauseSelectedDownload">暂停所选的下载</system:String>
+    <system:String x:Key="ResumeSelectedDownload">恢复所选的下载</system:String>
 
     <system:String x:Key="NoResultsFound">未找到结果</system:String>
-    <system:String x:Key="CheckingSubscription">正在检查订阅</system:String>
-    <system:String x:Key="CheckingCatalog">正在检查在线模组目录</system:String>
-    <system:String x:Key="UpdatedCatalogFrom">已从 {0} 更新在线模组目录</system:String>
-    <system:String x:Key="FailedToLoadSubscription">加载订阅失败</system:String>
-    <system:String x:Key="CatalogDownloadFailed">在线模组目录下载失败</system:String>
+    <system:String x:Key="CheckingSubscription">正在检查已安装的模组</system:String>
+    <system:String x:Key="CheckingCatalog">正在检查目录</system:String>
+    <system:String x:Key="UpdatedCatalogFrom">更新目录</system:String>
+    <system:String x:Key="FailedToLoadSubscription">已安装模组加载失败</system:String>
+    <system:String x:Key="CatalogDownloadFailed">目录下载失败</system:String>
 
-    <system:String x:Key="Starting">正在启动...</system:String>
-    <system:String x:Key="Pending">等待中...</system:String>
+    <system:String x:Key="Starting">正在开始...</system:String>
+    <system:String x:Key="Pending">待处理...</system:String>
     <system:String x:Key="Resuming">正在恢复...</system:String>
     <system:String x:Key="Paused">已暂停...</system:String>
     <system:String x:Key="Canceled">已取消</system:String>
     <system:String x:Key="Failed">失败</system:String>
 
-    <system:String x:Key="IsAlreadyDownloading">{0} 已经在下载中!</system:String>
-    <system:String x:Key="IsAlreadyUpdating">{0} 已经在更新中!</system:String>
-    <system:String x:Key="IsAlreadyDownloadedAndInstalled">{0} 已经下载并安装!</system:String>
+    <system:String x:Key="IsAlreadyDownloading">已经正在下载！</system:String>
+    <system:String x:Key="IsAlreadyUpdating">已经正在升级！</system:String>
+    <system:String x:Key="IsAlreadyDownloadedAndInstalled">已经下载安装过了！</system:String>
 
-    <system:String x:Key="NoLinksFor">没有链接可用于：</system:String>
-    <system:String x:Key="FailedToParseLinkFor">解析以下链接失败：</system:String>
-    <system:String x:Key="OpeningExternalUrlInBrowserFor">在浏览器打开外部 URL：</system:String>
+    <system:String x:Key="NoLinksFor">无链接指向</system:String>
+    <system:String x:Key="FailedToParseLinkFor">无法解析链接</system:String>
+    <system:String x:Key="OpeningExternalUrlInBrowserFor">在浏览器中打开外部链接</system:String>
 
     <system:String x:Key="ErrorDownloading">下载出错</system:String>
-    <system:String x:Key="WasCanceled">被取消</system:String>
-    <system:String x:Key="Error">错误</system:String>
-    
-    <system:String x:Key="ExternalUrlDownloadMessage1" xml:space="preserve">此模组只能通过从外部网站下载获得。
+    <system:String x:Key="WasCanceled">已经被取消</system:String>
+    <system:String x:Key="Error">出错</system:String>
 
-您想现在打开浏览器下载它吗？</system:String>
+    <system:String x:Key="ExternalUrlDownloadMessage1" xml:space="preserve">这个模组只能从外部网站下载。
+        
+你想现在打开网页浏览器下载它吗？</system:String>
 
-    <system:String x:Key="ExternalUrlDownloadMessage2" xml:space="preserve">模组自动下载失败。有一个可用的外部链接可以下载此模组。
+    <system:String x:Key="ExternalUrlDownloadMessage2" xml:space="preserve">模组自动下载失败。但它的外部下载链接是可用的。
 
-您想现在打开浏览器下载它吗？</system:String>
-    <system:String x:Key="SwitchingToBackupUrl">切换到备用 URL</system:String>
+你想现在打开网页浏览器下载它吗？</system:String>
+
+    <system:String x:Key="SwitchingToBackupUrl">切换到备用链接</system:String>
     <system:String x:Key="Downloading">正在下载</system:String>
     <system:String x:Key="Installing">正在安装</system:String>
 
 
     <!--ChunkToolViewModel Strings-->
-    <system:String x:Key="PathToFlevelRequired">需要 Flevel 路径。</system:String>
+    <system:String x:Key="PathToFlevelRequired">需要 Flevel 所在的文件夹路径。</system:String>
     <system:String x:Key="PathToOutputFolderRequired">需要输出文件夹路径。</system:String>
-    <system:String x:Key="SelectTheSectionsToExtract">选择要提取的区块。</system:String>
-    <system:String x:Key="FlevelFileDoesNotExistAtGivenPath">在给定路径下找不到 Flevel 文件。</system:String>
+    <system:String x:Key="SelectTheSectionsToExtract">选择要提取的区段。</system:String>
+    <system:String x:Key="FlevelFileDoesNotExistAtGivenPath">无法在指定的文件夹路径找到 Flevel文件。</system:String>
     <system:String x:Key="OutputFolderDoesNotExist">输出文件夹不存在。</system:String>
 
     <system:String x:Key="Complete">完成！</system:String>
-    <system:String x:Key="FailedToExtractTheErrorHasBeenLogged">提取失败。错误已记录</system:String>
+    <system:String x:Key="FailedToExtractTheErrorHasBeenLogged">提取失败。错误已记录。</system:String>
 
 
     <!--ConfigureModViewModel Strings-->
-    <system:String x:Key="ConfigureMod">配置模组</system:String>
+    <system:String x:Key="ConfigureMod">自定义配置</system:String>
 
     <system:String x:Key="ThisOptionCannotBeChangedDueToCompatibility">为了兼容其它模组，这个选项不可修改</system:String>
     <system:String x:Key="TheFollowingValuesHaveBeenRemovedDueToCompatibility"> {0} 选项已被移除，否则不兼容其它模组 ({1})</system:String>
 
-    <system:String x:Key="FailedToPlayPreviewAudio">播放预览音频失败</system:String>
+    <system:String x:Key="FailedToPlayPreviewAudio">预览音频播放失败</system:String>
 
 
     <!--DownloadItemViewModel Strings-->
@@ -418,44 +425,43 @@
     
     
     <!--GameLaunchSettingsViewModel Strings-->
-    <system:String x:Key="InsertAndClickImport">插入 {0} 并点击"导入"</system:String>
-    <system:String x:Key="GameLauncherSettingsUpdated">游戏启动器设置已更新！</system:String>
-    <system:String x:Key="FailedToSaveLaunchSettings">保存游戏启动器设置失败</system:String>
+    <system:String x:Key="InsertAndClickImport">选择 {0} 然后点击“导入”</system:String>
+    <system:String x:Key="GameLauncherSettingsUpdated">设置已更新！</system:String>
+    <system:String x:Key="FailedToSaveLaunchSettings">设置保存失败</system:String>
 
-    <system:String x:Key="ErrorCopyingFf7InputCfg">复制 ff7input.cfg 时出错</system:String>
-    <system:String x:Key="NoFf7InputCfgFoundAt">在以下位置未找到 ff7input.cfg：</system:String>
-    <system:String x:Key="AlreadyExistsAt">已存在以下位置：</system:String>
+    <system:String x:Key="ErrorCopyingFf7InputCfg">复制 ff7input.cfg 失败</system:String>
+    <system:String x:Key="NoFf7InputCfgFoundAt">ff7input.cfg 并没有存在于</system:String>
+    <system:String x:Key="AlreadyExistsAt">已经存在于</system:String>
 
-    <system:String x:Key="ChoosingAnyOtherOptionBesidesCustom7HGameDriver">选择"自定义 7H 游戏驱动"以外的任何选项将导致使用 7H 安装的模组不再工作！</system:String>
+    <system:String x:Key="ChoosingAnyOtherOptionBesidesCustom7HGameDriver">选择除了“自定义第七天堂游戏驱动”以外的任何选项，将会导致第七天堂安装的模组无法正常工作！</system:String>
     
-    <system:String x:Key="ReunionWarningMessage" xml:space="preserve">Reunion R06及更新版本，即使在 Options.ini 中禁用，也会在运行 FF7 时强制加载自定义游戏驱动。这与 7th Heaven 的游戏驱动冲突，会破坏您的图形设置，您将遇到问题。
+    <system:String x:Key="ReunionWarningMessage" xml:space="preserve">Reunion R06 及更新版本，即使在 Options.ini 中已禁用，也会在运行FF7时强制加载自定义游戏驱动。这会与第七天堂的游戏驱动冲突，破坏图形设置。
 
-如果您想玩 Reunion，请使用为 7th Heaven 构建的兼容模组版本。
+如果你想游玩 Reunion模组，请使用为第七天堂构建的兼容版本。
 
-您确定吗？</system:String>
+确定要继续吗？</system:String>
 
-    <system:String x:Key="YouShouldLeaveThisSettingOn">您应该保持此设置开启！</system:String>
-    <system:String x:Key="ProgramToRunNotFound">找不到要运行的程序</system:String>
+    <system:String x:Key="YouShouldLeaveThisSettingOn">不要关闭此选项！</system:String>
+    <system:String x:Key="ProgramToRunNotFound">未找到要运行的程序</system:String>
 
-    <system:String x:Key="ImportMissingMoviesWarningMessage" xml:space="preserve">这将从您的游戏光盘复制缺失的过场动画文件到"常规设置"中的过场动画路径。
-此过程将覆盖 {0} 中已有的任何过场动画文件。
+    <system:String x:Key="ImportMissingMoviesWarningMessage" xml:space="preserve">这个操作将从游戏光盘提取过场动画文件，并复制到游戏文件夹。这个过程将会覆盖 {0} 中已经存在的过场动画文件。
 
-您要继续吗？</system:String>
+确定要继续吗？</system:String>
 
-    <system:String x:Key="LookingFor">正在查找</system:String>
-    <system:String x:Key="InsertToContinue">插入 {0} 以继续。</system:String>
+    <system:String x:Key="LookingFor">正在寻找</system:String>
+    <system:String x:Key="InsertToContinue">插入 {0} 以便继续</system:String>
     
-    <system:String x:Key="PleaseInsertToContinueCopying" xml:space="preserve">请插入 {0} 以继续复制缺失的过场动画文件。
+    <system:String x:Key="PleaseInsertToContinueCopying" xml:space="preserve">请插入 {0} 以便继续复制缺失的过场动画文件。
 
-点击"取消"停止此过程。</system:String>
+点击“取消”中止进程。</system:String>
 
-    <system:String x:Key="FoundDiscAt">发现 {0} 位置：</system:String>
+    <system:String x:Key="FoundDiscAt">{0} 已在下列位置找到: </system:String>
     <system:String x:Key="Overwriting">正在覆盖</system:String>
     <system:String x:Key="Copying">正在复制</system:String>
-    <system:String x:Key="FailedToFindAt">在 {1} 查找 {0} 失败</system:String>
-    <system:String x:Key="AnErrorOccurredCopyingMovies">复制过场动画时发生错误</system:String>
-    <system:String x:Key="SuccessfullyCopiedMovies">成功复制过场动画。</system:String>
-    <system:String x:Key="FinishedCopyingMoviesSomeFailed">过场动画复制完成。部分过场动画复制失败。查看 app.log 获取详情。</system:String>
+    <system:String x:Key="FailedToFindAt">无法在 {1} 找到 {0}</system:String>
+    <system:String x:Key="AnErrorOccurredCopyingMovies">复制过场动画文件时发生错误</system:String>
+    <system:String x:Key="SuccessfullyCopiedMovies">过场动画文件已成功复制。</system:String>
+    <system:String x:Key="FinishedCopyingMoviesSomeFailed">过场动画文件复制完成。部分文件复制失败。详见程序日志。</system:String>
 
     <system:String x:Key="SaveControlConfiguration">保存按键设置</system:String>
     <system:String x:Key="ImportCurrentControlsFromGameAndSaveAs">从游戏中导入当前的按键设置，并另存为...</system:String>
@@ -463,7 +469,7 @@
     <system:String x:Key="ControlNameIsEmpty">按键配置文件的名称不能为空。</system:String>
     <system:String x:Key="ControlNameContainsInvalidChars">按键配置文件的名称不能包含特殊符号。</system:String>
 
-    <system:String x:Key="ControlsWithThatNameAlreadyExist">已存在同名的自定义按键配置文件。</system:String>
+    <system:String x:Key="ControlsWithThatNameAlreadyExist">已存在同名文件。</system:String>
 
     <system:String x:Key="SuccessfullyCreatedCustomControls">自定义按键配置文件创建成功。</system:String>
     <system:String x:Key="FailedToCreateCustomControls">自定义按键配置文件创建失败。</system:String>
@@ -477,761 +483,798 @@
     <system:String x:Key="GeneralSettingsHaveBeenUpdated">常规设置已更新！</system:String>
 
     <system:String x:Key="SettingsNotValid">设置无效</system:String>
-    <system:String x:Key="MissingFf7ExePath">缺少 FF7 Exe 路径。</system:String>
-    <system:String x:Key="Ff7ExePathChanged">检测到游戏文件夹路径更改，强烈建议您重新启动 7th Heaven，现在要重启吗？</system:String>
-    <system:String x:Key="MissingLibraryPath">缺少存放模组的文件夹路径。</system:String>
-    <system:String x:Key="MissingTexturesPath">缺少纹理(Aali OpenGL)路径。</system:String>
-    <system:String x:Key="MissingMoviePath">缺少过场动画路径。</system:String>
-    <system:String x:Key="LibraryPathCannotBeGameOrApp">存放模组的文件夹路径不能是 7th Heaven 软件根目录，也不能是游戏根目录！</system:String>
+    <system:String x:Key="MissingFf7ExePath">FF7 exe 文件路径丢失</system:String>
+    <system:String x:Key="Ff7ExePathChanged">检测到游戏文件夹路径已改变，是否重新启动第七天堂？</system:String>
+    <system:String x:Key="MissingLibraryPath">存放模组的文件夹路径丢失</system:String>
+    <system:String x:Key="MissingTexturesPath">存放自定义贴图 (Aali OpenGL) 的文件夹路径丢失</system:String>
+    <system:String x:Key="MissingMoviePath">过场动画文件路径丢失</system:String>
+    <system:String x:Key="LibraryPathCannotBeGameOrApp">存放模组的文件夹路径不能是第七天堂软件根目录，也不能是游戏根目录！请使用默认路径或选择其他非上述路径。</system:String>
 
-    <system:String x:Key="FailedToRegisterIroModFilesWith7thHeaven">注册 .iro 模组文件到 7th Heaven 失败</system:String>
-    <system:String x:Key="FailedToUnregisterIroModFilesWith7thHeaven">从 7th Heaven 取消注册 .iro 模组文件失败</system:String>
-    <system:String x:Key="FailedToUnregisterIrosLinksWith7thHeaven">从 7th Heaven 取消注册 iros://链接失败</system:String>
-    <system:String x:Key="FailedToRegisterIrosLinksWith7thHeaven">注册 iros://链接到 7th Heaven 失败</system:String>
-    <system:String x:Key="FailedToCreate7thHeavenContextMenuEntries">在 Windows 资源管理器中创建 7th Heaven 上下文菜单项失败</system:String>
-    <system:String x:Key="FailedToRemove7thHeavenContextMenuEntries">从 Windows 资源管理器中移除 7th Heaven 上下文菜单项失败</system:String>
+    <system:String x:Key="FailedToRegisterIroModFilesWith7thHeaven">无法将.iro模组文件的打开方式注册为 7th Heaven</system:String>
+    <system:String x:Key="FailedToUnregisterIroModFilesWith7thHeaven">无法取消注册 7th Heaven 作为.iro模组文件的打开方式</system:String>
+    <system:String x:Key="FailedToUnregisterIrosLinksWith7thHeaven">无法取消注册 7th Heaven 作为 iros:// 链接的打开方式</system:String>
+    <system:String x:Key="FailedToRegisterIrosLinksWith7thHeaven">无法将 iros:// 链接的打开方式注册为 7th Heaven</system:String>
+    <system:String x:Key="FailedToCreate7thHeavenContextMenuEntries">无法在 Windows资源管理器中创建 7th Heaven 右键菜单选项</system:String>
+    <system:String x:Key="FailedToRemove7thHeavenContextMenuEntries">无法在 Windows资源管理器中移除 7th Heaven 右键菜单选项</system:String>
 
     <system:String x:Key="CatalogNameWillAutoResolveOnSave">目录名称将在保存时自动解析</system:String>
-    <system:String x:Key="ResolvingCatalogName">正在解析目录名称...</system:String>
-    <system:String x:Key="UrlMustBeInIrosFormat">URL 必须是 iros:// 格式</system:String>
-    <system:String x:Key="ResolvingCatalogNameFor">为以下链接解析目录名称：</system:String>
+    <system:String x:Key="ResolvingCatalogName">正在解析目录名称 ...</system:String>
+    <system:String x:Key="UrlMustBeInIrosFormat">链接必须是 iros:// 格式</system:String>
+    <system:String x:Key="ResolvingCatalogNameFor">正在解析以下目录的名称: </system:String>
     
     
     <!--ImportModViewModel Strings-->
-    <system:String x:Key="SelectAnIroFileToImport">选择一个 .iro 或 .irop 文件，然后导入存放模组的文件夹。</system:String>
-    <system:String x:Key="SelectAFolderThatContainsModFiles">选择一个包含未封包模组内容的文件夹，它将会被复制到存放模组的文件夹。</system:String>
-    <system:String x:Key="SelectAFolderThatContainsIroModFilesAndFolders">选择 .iro 文件，以及包含未封包模组内容的文件夹，它们都会被复制到存放模组的文件夹。</system:String>
-    <system:String x:Key="ImportingModsPleaseWait">正在导入模组...请稍候...</system:String>
+    <system:String x:Key="SelectAnIroFileToImport">选择一个 .iro 或 .irop 文件导入到存放模组的文件夹。</system:String>
+    <system:String x:Key="SelectAFolderThatContainsModFiles">选择一个包含模组文件的文件夹。模组文件将被复制到“存放模组的文件夹”。</system:String>
+    <system:String x:Key="SelectAFolderThatContainsIroModFilesAndFolders">选择一个包含.iro模组文件和模组文件夹的位置。所有找到的模组文件将被复制到“存放模组的文件夹”。</system:String>
+    <system:String x:Key="ImportingModsPleaseWait">正在导入模组... 请稍等 ...</system:String>
 
-    <system:String x:Key="ValidationError">验证错误</system:String>
-    <system:String x:Key="ImportError">导入错误</system:String>
+    <system:String x:Key="ValidationError">验证出错</system:String>
+    <system:String x:Key="ImportError">导入出错</system:String>
 
-    <system:String x:Key="EnterPathToAnIroFile">输入 .iro 文件的路径。</system:String>
-    <system:String x:Key="IroFileDoesNotExist">.iro 文件不存在。</system:String>
+    <system:String x:Key="EnterPathToAnIroFile">请输入.iro文件所在文件夹的路径。</system:String>
+    <system:String x:Key="IroFileDoesNotExist">.iro文件不存在。</system:String>
 
-    <system:String x:Key="SuccessfullyImported">成功导入</system:String>
+    <system:String x:Key="SuccessfullyImported">已成功导入</system:String>
     <system:String x:Key="CanNotImportMod">无法导入模组。</system:String>
     <system:String x:Key="FailedToImportModTheErrorHasBeenLogged">导入模组失败。错误已记录。</system:String>
 
-    <system:String x:Key="EnterPathToFolderContainingModFiles">输入一个包含未封包模组内容的文件夹路径。</system:String>
-    <system:String x:Key="DirectoryDoesNotExist">存放模组的文件夹不存在。</system:String>
+    <system:String x:Key="EnterPathToFolderContainingModFiles">请输入包含模组文件的文件夹路径。</system:String>
+    <system:String x:Key="DirectoryDoesNotExist">文件夹不存在。</system:String>
 
-    <system:String x:Key="EnterPathToFolderContainingIroFilesOrModFolders">输入一个包含 .iro 文件，以及包含未封包模组内容的文件夹路径。</system:String>
+    <system:String x:Key="EnterPathToFolderContainingIroFilesOrModFolders">请输入包含 .iro文件、模组文件夹的路径。</system:String>
 
     <!--MegaLinkGenUserControl Strings-->
     <system:String x:Key="GenerateLinks">生成链接</system:String>
 
     <!--MegaLinkGenViewModel Strings-->
-    <system:String x:Key="GeneratingLinks">正在生成链接...</system:String>
+    <system:String x:Key="GeneratingLinks">正在生成链接 ...</system:String>
     <system:String x:Key="FailedToGenerateLinks">生成链接失败</system:String>
-    <system:String x:Key="EnterMegaFolderIdToGenerateLinks">输入 Mega 文件夹编号以生成链接。</system:String>
-    <system:String x:Key="NoLinksFoundInFolder">在文件夹中找不到链接</system:String>
+    <system:String x:Key="EnterMegaFolderIdToGenerateLinks">请输入要生成链接的 Mega网盘文件夹ID。</system:String>
+    <system:String x:Key="NoLinksFoundInFolder">文件夹中找不到链接</system:String>
     
     
     <!--CreateModUserControl Strings-->
     <system:String x:Key="Generate">生成</system:String>
     <system:String x:Key="Info">信息</system:String>
-    <system:String x:Key="MakeSureToCopyToTheRootFolder">确保将 {0} 复制到模组的根文件夹，以便正确加载预览图像。</system:String>
+    <system:String x:Key="MakeSureToCopyToTheRootFolder">将 {0} 复制到模组根目录，才能正确加载预览图像。</system:String>
 
     <!--ModCreationViewModel Strings-->
-    <system:String x:Key="CouldNotLoadModXml">无法加载 mod.xml</system:String>
-    <system:String x:Key="CouldNotSaveModXml">无法保存 mod.xml</system:String>
-    <system:String x:Key="SuccessfullySavedTo">成功保存到：</system:String>
+    <system:String x:Key="CouldNotLoadModXml">无法加载模组xml</system:String>
+    <system:String x:Key="CouldNotSaveModXml">无法保存模组xml</system:String>
+    <system:String x:Key="SuccessfullySavedTo">已成功保存到</system:String>
     
     
     <!--OpenProfileWindow Strings-->
-    <system:String x:Key="LoadProfile">加载预设配置文件</system:String>
-    <system:String x:Key="SaveCurrentProfileAs">将当前配置文件另存为...</system:String>
-    <system:String x:Key="CopySelectedProfileToNewProfile">将选定配置文件复制为新配置文件</system:String>
-    <system:String x:Key="DeleteSelectedProfile">删除选定配置文件</system:String>
-    <system:String x:Key="ViewSelectedProfileDetails">查看选定配置文件详情</system:String>
+    <system:String x:Key="LoadProfile">加载预设文件</system:String>
+    <system:String x:Key="SaveCurrentProfileAs">将当前预设文件另存为 ...</system:String>
+    <system:String x:Key="CopySelectedProfileToNewProfile">复制所选的预设文件</system:String>
+    <system:String x:Key="DeleteSelectedProfile">删除所选的预设文件</system:String>
+    <system:String x:Key="ViewSelectedProfileDetails">查看所选预设文件的参数</system:String>
 
-    <system:String x:Key="AreYouSureYouWantToDeleteSelectedProfile">您确定要删除选定的配置文件吗?</system:String>
+    <system:String x:Key="AreYouSureYouWantToDeleteSelectedProfile">确定删除所选的预设文件吗</system:String>
 
-    <system:String x:Key="NoProfileSelected">未选择配置文件</system:String>
-    <system:String x:Key="SelectProfileToContinue">选择配置文件以继续</system:String>
+    <system:String x:Key="NoProfileSelected">未选择预设文件</system:String>
+    <system:String x:Key="SelectProfileToContinue">选择一个预设文件以继续</system:String>
 
 
     <!--OpenProfileViewModel Strings-->
-    <system:String x:Key="ActiveProfileFileDoesNotExist">活动配置文件不存在</system:String>
-    <system:String x:Key="EnterProfileName">输入配置文件名称：</system:String>
-    <system:String x:Key="SaveActiveProfile">保存活动配置文件</system:String>
-    <system:String x:Key="SuccessfullySavedAsNewProfile">成功将 {0 }保存为新配置文件 {1}！</system:String>
-    <system:String x:Key="FailToSaveAsNewProfile">将 {0} 保存为新配置文件 {1} 失败：{2}</system:String>
+    <system:String x:Key="ActiveProfileFileDoesNotExist">正在使用的预设文件不存在</system:String>
+    <system:String x:Key="EnterProfileName">输入预设文件名称:</system:String>
+    <system:String x:Key="SaveActiveProfile">保存正在使用的预设文件</system:String>
+    <system:String x:Key="SuccessfullySavedAsNewProfile">成功将 {0} 保存为新的预设文件 {1}！</system:String>
+    <system:String x:Key="FailToSaveAsNewProfile">无法将 {0} 保存为新预设文件 {1}: {2}</system:String>
 
-    <system:String x:Key="ProfileDoesNotExist">配置文件不存在</system:String>
-    <system:String x:Key="HasItBeenDeletedAlready">它是否已被删除？</system:String>
-    <system:String x:Key="SuccessfullyDeletedProfile">成功删除配置文件</system:String>
-    <system:String x:Key="FailedToDeleteProfile">删除配置文件失败</system:String>
+    <system:String x:Key="ProfileDoesNotExist">预设文件不存在</system:String>
+    <system:String x:Key="HasItBeenDeletedAlready">是否已经删除？</system:String>
+    <system:String x:Key="SuccessfullyDeletedProfile">已成功删除预设文件</system:String>
+    <system:String x:Key="FailedToDeleteProfile">预设文件删除失败</system:String>
 
-    <system:String x:Key="EnterProfileNameForTheCopy">输入副本的配置文件名称：</system:String>
-    <system:String x:Key="CopyProfile">复制配置文件</system:String>
-    <system:String x:Key="NewProfile">新配置文件</system:String>
-    <system:String x:Key="SuccessfullyCopiedProfile">成功将配置文件 {0} 复制为新配置文件 {1}</system:String>
-    <system:String x:Key="FailedToCopyProfile">将配置文件 {0} 复制为 {1} 失败</system:String>
+    <system:String x:Key="EnterProfileNameForTheCopy">为复制的预设文件命名:</system:String>
+    <system:String x:Key="CopyProfile">复制预设</system:String>
+    <system:String x:Key="NewProfile">新建预设</system:String>
+    <system:String x:Key="SuccessfullyCopiedProfile">成功将 {0} 复制为新的预设文件 {1}</system:String>
+    <system:String x:Key="FailedToCopyProfile">无法将预设文件 {0} 复制为 {1}</system:String>
 
-    <system:String x:Key="FailedToOpenProfileDetails">打开配置文件详情失败</system:String>
-    <system:String x:Key="ProfileNameIsEmpty">配置文件名称为空。</system:String>
-    <system:String x:Key="ProfileError">配置文件错误</system:String>
+    <system:String x:Key="FailedToOpenProfileDetails">无法打开预设文件查看参数</system:String>
+    <system:String x:Key="ProfileNameIsEmpty">预设文件名称为空。</system:String>
+    <system:String x:Key="ProfileError">预设文件出错</system:String>
 
-    <system:String x:Key="WarningProfileXmlDoesNotExistCanNotSwitch">警告: {0} 的配置文件 xml 文件不存在。无法切换配置文件！</system:String>
-    <system:String x:Key="LoadedProfile">加载配置文件</system:String>
-    <system:String x:Key="FailedToSwitchToProfile">切换到配置文件失败</system:String>
+    <system:String x:Key="WarningProfileXmlDoesNotExistCanNotSwitch">警告：{0} 的预设文件 xml 不存在。无法切换预设文件！</system:String>
+    <system:String x:Key="LoadedProfile">已加载预设文件</system:String>
+    <system:String x:Key="FailedToSwitchToProfile">预设文件切换失败</system:String>
 
 
     <!--PackIroViewModel Strings-->
     <system:String x:Key="PathToSourceFolderIsRequired">需要源文件夹路径</system:String>
-    <system:String x:Key="PathToOutputIroFileIsRequired">需要输出 iro 文件路径</system:String>
-    <system:String x:Key="SelectCompressionOption">选择压缩选项</system:String>
-    <system:String x:Key="InvalidPackIroOptions">非法打包 iro 选项</system:String>
-    <system:String x:Key="AnErrorOccuredWhilePacking">打包时发生错误</system:String>
-    <system:String x:Key="PackingComplete">打包完成!</system:String>
+    <system:String x:Key="PathToOutputIroFileIsRequired">需要输出iro文件的路径</system:String>
+    <system:String x:Key="SelectCompressionOption">选择一个压缩选项</system:String>
+    <system:String x:Key="InvalidPackIroOptions">无效的iro打包设置</system:String>
+    <system:String x:Key="AnErrorOccuredWhilePacking">打包过程出错</system:String>
+    <system:String x:Key="PackingComplete">打包完成！</system:String>
 
     
     <!--PatchIroViewModel Strings-->
-    <system:String x:Key="PathToOriginalIroIsRequired">需要原始 iro 路径</system:String>
-    <system:String x:Key="PathToNewIroFileIsRequired">需要新 iro 文件路径</system:String>
-    <system:String x:Key="PathToIropFileIsRequired">需要保存的 irop 文件路径</system:String>
-    <system:String x:Key="AnErrorOccuredWhilePatching">修补时发生错误</system:String>
-    <system:String x:Key="PatchingComplete">修补完成!</system:String>
+    <system:String x:Key="PathToOriginalIroIsRequired">需要原始iro文件的路径</system:String>
+    <system:String x:Key="PathToNewIroFileIsRequired">需要新的iro文件的路径</system:String>
+    <system:String x:Key="PathToIropFileIsRequired">需要iro文件的保存路径</system:String>
+    <system:String x:Key="AnErrorOccuredWhilePatching">修补过程出错</system:String>
+    <system:String x:Key="PatchingComplete">修补完成！</system:String>
     
     
     <!--ThemeSettingsWindow Strings-->
-    <system:String x:Key="ChangeColorThemeWindowTitle">更改颜色主题</system:String>
-    <system:String x:Key="ExportTheme">导出主题...</system:String>
+    <system:String x:Key="ChangeColorThemeWindowTitle">更改配色主题</system:String>
+    <system:String x:Key="ExportTheme">导出主题 ...</system:String>
 
     <!--ThemeSettingsViewModel Strings-->
     <system:String x:Key="ThemeSaved">主题已保存！</system:String>
-    <system:String x:Key="ThemeSavedAs">主题已另存为 {0}</system:String>
-    <system:String x:Key="FailedToSaveTheme">保存主题失败...</system:String>
-    <system:String x:Key="FailedToLoadTheme">加载主题失败</system:String>
-    <system:String x:Key="ThemeLoadedClickSavveToSaveThis">主题已加载!点击"保存"将此主题保存为默认...</system:String>
+    <system:String x:Key="ThemeSavedAs">主题另存为</system:String>
+    <system:String x:Key="FailedToSaveTheme">主题保存失败...</system:String>
+    <system:String x:Key="FailedToLoadTheme">主题加载失败</system:String>
+    <system:String x:Key="ThemeLoadedClickSavveToSaveThis">主题已加载！点击“保存”将这个主题保存为默认 ...</system:String>
     <system:String x:Key="SelectBackgroundImageFile">选择背景图片文件</system:String>
 
     
     <!--UnpackIroViewModel Strings-->
-    <system:String x:Key="PathToSourceIroFileIsRequired">需要源 iro 文件路径</system:String>
-    <system:String x:Key="InvalidUnpackIroOptions">非法 unpack iro 选项</system:String>
-    <system:String x:Key="AnErrorOccuredWhileUnpacking">解包时发生错误</system:String>
+    <system:String x:Key="PathToSourceIroFileIsRequired">需要iro源文件路径</system:String>
+    <system:String x:Key="InvalidUnpackIroOptions">无效的iro解包设置</system:String>
+    <system:String x:Key="AnErrorOccuredWhileUnpacking">解包过程出错</system:String>
     <system:String x:Key="UnpackingComplete">解包完成！</system:String>
 
     
     <!--CreateCatalogUserControl Strings-->
     <system:String x:Key="RemoveMod">移除模组</system:String>
-    <system:String x:Key="Add">新增</system:String>
+    <system:String x:Key="Add">添加</system:String>
 
     <!--CatalogCreationViewModel Strings-->
-    <system:String x:Key="CouldNotLoadModXmlFromIroFile">无法从 .iro 文件加载 mod.xml</system:String>
-    <system:String x:Key="CouldNotLoadCatalogXml">无法加载 catalog.xml</system:String>
+    <system:String x:Key="CouldNotLoadModXmlFromIroFile">无法从.iro文件中加载模组xml</system:String>
+    <system:String x:Key="CouldNotLoadCatalogXml">无法加载目录xml</system:String>
 
     
     <!--ConfigureGLWindow.xaml.cs Strings-->
     <system:String x:Key="FailedToReadRequiredSpecXmlFile">无法读取显示设置所需的 spec xml 文件。窗口必须关闭。</system:String>
-    <system:String x:Key="WillDeleteEverythingUnder">将删除 {0} 下的所有内容</system:String>
+    <system:String x:Key="WillDeleteEverythingUnder">将会删除以下的所有内容: </system:String>
     <system:String x:Key="PathToCacheFolderDoesNotExist">缓存文件夹路径不存在。</system:String>
     <system:String x:Key="TextureCacheCleared">纹理缓存已清除！</system:String>
-    <system:String x:Key="FailedToClearTextureCache">清除纹理缓存失败</system:String>
+    <system:String x:Key="FailedToClearTextureCache">纹理缓存清除失败</system:String>
     <system:String x:Key="GameDriverSettingsSaved">游戏驱动设置已保存！</system:String>
-    <system:String x:Key="CouldNotWriteTo7HGameDriverCfg">无法写入 7H_GameDriver.cfg 文件。检查它是否未设置为只读，并且 FF7 安装在您有完全写入权限的文件夹中。</system:String>
+    <system:String x:Key="CouldNotWriteTo7HGameDriverCfg">无法写入 FFNx.toml 文件。请检查文件属性是否为只读，并确保FF7安装在“有完全写入权限”的文件夹中。</system:String>
     <system:String x:Key="UnknownErrorWhileSaving">保存时发生未知错误。错误已记录。</system:String>
-    <system:String x:Key="GameDriverSettingsResetToDefaults">游戏驱动设置已重置为默认值。点击"保存"保存更改。</system:String>
+    <system:String x:Key="GameDriverSettingsResetToDefaults">游戏驱动设置已还原到默认值。点击“保存”以保存更改。</system:String>
+
     
     
     <!--GameLaunchSettingsWindow.xaml.cs Strings-->
     <system:String x:Key="SelectProgramToRemove">选择要删除的程序。</system:String>
     <system:String x:Key="SelectProgramToEdit">选择要编辑的程序。</system:String>
     <system:String x:Key="SelectProgramToMove">选择要移动的程序。</system:String>
-    <system:String x:Key="SelectProgramToRunSuchAs">选择要运行的程序，如 .exe 或脚本</system:String>
+    <system:String x:Key="SelectProgramToRunSuchAs">选择要运行的程序，例如 .exe 或脚本</system:String>
     
     
     <!--GameLaunchWindow.xaml.cs Strings-->
-    <system:String x:Key="LaunchingFinalFantasyVII">正在启动 FF7</system:String>
+    <system:String x:Key="LaunchingFinalFantasyVII">正在启动 最终幻想VII</system:String>
     <system:String x:Key="UnknownErrorWhenLaunchingGame">启动游戏时发生未知错误</system:String>
     <system:String x:Key="GameLaunchProcessCanceled">游戏启动过程已取消</system:String>
-    <system:String x:Key="FailedToLaunchFf7ViewLogForDetails">启动 FF7 失败。查看上方日志获取详情。</system:String>
-    <system:String x:Key="SuccessfullyLaunchedFf7">成功启动 FF7!</system:String>
+    <system:String x:Key="FailedToLaunchFf7ViewLogForDetails">FF7启动失败。请查看上方日志了解详情。</system:String>
+    <system:String x:Key="SuccessfullyLaunchedFf7">FF7启动成功！</system:String>
     
     
     <!--GeneralSettingsWindow Strings-->
-    <system:String x:Key="ActivateNewlyInstalledModsAutomatically">自动激活新安装的模组</system:String>
+    <system:String x:Key="ActivateNewlyInstalledModsAutomatically">新安装的模组自动开启</system:String>
     <system:String x:Key="ImportModsFromLibraryAutomatically">从存放模组的文件夹自动导入新模组</system:String>
     <system:String x:Key="WarnWhenModContainsCode">当模组包含注入型代码时提出警告</system:String>
     <system:String x:Key="AutoSortModsByDefault">自动调整模组加载顺序</system:String>
-    <system:String x:Key="AutoUpdateModsByDefault">自动更新模组</system:String>
+    <system:String x:Key="AutoUpdateModsByDefault">自动升级模组</system:String>
     <system:String x:Key="IgnoreModCompatibilityRestrictions">忽略模组兼容规则</system:String>
-    <system:String x:Key="CheckFor7thHeavenUpdatesAutomatically">自动检查 7th Heaven 更新</system:String>
+    <system:String x:Key="CheckFor7thHeavenUpdatesAutomatically">自动检查第七天堂新版本</system:String>
 
-    <system:String x:Key="OpenIrosLinksWith7thHeaven">使用 7th Heaven 打开 iros://链接</system:String>
-    <system:String x:Key="OpenModFilesWith7thHeaven">使用 7th Heaven 打开模组文件</system:String>
-    <system:String x:Key="ContextMenuInExplorer">资源管理器中的上下文菜单</system:String>
+    <system:String x:Key="OpenIrosLinksWith7thHeaven">用第七天堂打开 iros:// 链接</system:String>
+    <system:String x:Key="OpenModFilesWith7thHeaven">用第七天堂打开 .iro 模组文件</system:String>
+    <system:String x:Key="ContextMenuInExplorer">右键菜单选项</system:String>
 
-    <system:String x:Key="PathsHeader" xml:space="preserve">游戏路径</system:String>
-    <system:String x:Key="ShellIntegrationHeader" xml:space="preserve">Shell 集成</system:String>
-    <system:String x:Key="CatalogSubscriptionsHeader" xml:space="preserve">在线模组目录订阅：</system:String>
-    <system:String x:Key="AdditionalFoldersToMonitorHeader" xml:space="preserve">游戏根目录下必要的文件夹：</system:String>
+    <system:String x:Key="PathsHeader" xml:space="preserve"> 游戏路径 </system:String>
+    <system:String x:Key="ShellIntegrationHeader" xml:space="preserve"> Shell 集成 </system:String>
+    <system:String x:Key="CatalogSubscriptionsHeader" xml:space="preserve"> 在线模组目录订阅: </system:String>
+    <system:String x:Key="AdditionalFoldersToMonitorHeader" xml:space="preserve"> 游戏根目录下必要的文件夹: </system:String>
 
-    <system:String x:Key="Url">Url</system:String>
+    <system:String x:Key="Url">链接</system:String>
 
-    <system:String x:Key="ErrorIncorrectExe">错误 - 错误的 Exe</system:String>
-    <system:String x:Key="ThisExeIsUsedForSteamReleaseFailedToCopyExe">此 exe 用于 Steam 版 FF7，7th Heaven 不支持。1.02版本的 ff7.exe 复制失败，无法自动为您选择。</system:String>
-    <system:String x:Key="ThisExeIsUsedForSteamReleaseCopiedSelectedForYou">此 exe 用于 Steam 版FF7，7th Heaven 不支持。1.02版本的 ff7.exe 是 {0} 以确保 7th Heaven 工作。</system:String>
-    <system:String x:Key="Selected">选择</system:String>
-    <system:String x:Key="CopiedAndSelected">复制并选择</system:String>
-    <system:String x:Key="ThisExeIsUsedForConfiguringFf7Settings">此 exe 用于配置 FF7 设置，不是正确的游戏 exe。请选择不同的 FF7 EXE 文件。</system:String>
+    <system:String x:Key="ErrorIncorrectExe">出错 - 不正确的exe文件</system:String>
+    <system:String x:Key="ThisExeIsUsedForSteamReleaseFailedToCopyExe">这个exe适用于FF7 Steam版，而第七天堂不支持该版本。ff7.exe的1.02补丁复制失败，无法自动选择。</system:String>
+    <system:String x:Key="ThisExeIsUsedForSteamReleaseCopiedSelectedForYou">这个exe适用于FF7 Steam版，而第七天堂不支持该版本。ff7.exe的1.02补丁{0}，以确保第七天堂能正常运行。</system:String>
+    <system:String x:Key="Selected">已应用</system:String>
+    <system:String x:Key="CopiedAndSelected">已复制并应用</system:String>
+    <system:String x:Key="ThisExeIsUsedForConfiguringFf7Settings">这个exe用于配置FF7，并不是正确的游戏exe。请选择其它 FF7 EXE文件.</system:String>
 
-    <system:String x:Key="SelectFf7Exe">选择 FF7.exe 或 FF7_en.exe</system:String>
-    <system:String x:Key="SelectMoviesFolder">选择过场动画文件夹</system:String>
-    <system:String x:Key="SelectTexturesFolder">选择纹理文件夹</system:String>
-    <system:String x:Key="Select7thHeavenLibraryFolder">选择存放模组的 7th Heaven 库文件夹</system:String>
+    <system:String x:Key="SelectFf7Exe">选择 FF7_en或FF7.exe</system:String>
+    <system:String x:Key="SelectMoviesFolder">选择过场动画 movies文件夹</system:String>
+    <system:String x:Key="SelectTexturesFolder">选择外置贴图 Textures文件夹</system:String>
+    <system:String x:Key="Select7thHeavenLibraryFolder">选择存放模组的文件夹</system:String>
 
-    <system:String x:Key="SelectSubscriptionToEdit">选择要编辑的订阅。</system:String>
-    <system:String x:Key="SelectSubscriptionToRemove">选择要删除的订阅。</system:String>
-    <system:String x:Key="SelectSubscriptionToMove">选择要移动的订阅。</system:String>
+    <system:String x:Key="SelectSubscriptionToEdit">选择一个要修改的订阅链接</system:String>
+    <system:String x:Key="SelectSubscriptionToRemove">选择一个要删除的订阅链接</system:String>
+    <system:String x:Key="SelectSubscriptionToMove">选择一个要移动的订阅链接</system:String>
 
-    <system:String x:Key="SelectFolderToRemove">选择要删除的文件夹。</system:String>
-    <system:String x:Key="SelectFolderToMove">选择要移动的文件夹。</system:String>
+    <system:String x:Key="SelectFolderToRemove">选择一个要删除的文件夹</system:String>
+    <system:String x:Key="SelectFolderToMove">选择一个要移动的文件夹</system:String>
     
     
     <!--ImportModWindow Strings-->
-    <system:String x:Key="FromIROFile">从 IRO 文件</system:String>
+    <system:String x:Key="FromIROFile">从 IRO文件</system:String>
     <system:String x:Key="FromFolder">从文件夹</system:String>
     <system:String x:Key="BatchImport">批量导入</system:String>
-    <system:String x:Key="SelectIroFile">选择 .iro 文件</system:String>
+    <system:String x:Key="SelectIroFile">选择.iro文件</system:String>
 
 
     <!--IroCreateWindow Strings-->
-    <system:String x:Key="PackIRO">打包 IRO</system:String>
-    <system:String x:Key="UnpackIRO">解包 IRO</system:String>
-    <system:String x:Key="PatchIRO">修补 IRO</system:String>
-    <system:String x:Key="PatchIROAdvanced">修补 IRO(高级)</system:String>
+    <system:String x:Key="PackIRO">打包IRO</system:String>
+    <system:String x:Key="UnpackIRO">解包IRO</system:String>
+    <system:String x:Key="PatchIRO">修补IRO</system:String>
+    <system:String x:Key="PatchIROAdvanced">修补IRO (高级)</system:String>
 
 
     <!--UnhandledErrorWindow Strings-->
-    <system:String x:Key="AnUnhandledExceptionOccurredAppMustClose">发生未处理的异常，应用程序必须关闭。</system:String>
+    <system:String x:Key="AnUnhandledExceptionOccurredAppMustClose">出现了未处理的异常，第七天堂必须关闭。</system:String>
 
 
-    <system:String x:Key="SelectLanguage">选择语言：</system:String>
-    <system:String x:Key="English">English</system:String>
-    <system:String x:Key="French">Français</system:String>
-    <system:String x:Key="German">Deutsch</system:String>
-    <system:String x:Key="Greek">Ελληνικά</system:String>
-    <system:String x:Key="Japanese">日本語</system:String>
-    <system:String x:Key="Spanish">Español</system:String>
-    <system:String x:Key="SimplifiedChinese">中文简体</system:String>
-    
+    <system:String x:Key="SelectLanguage">选择语言:</system:String>
+    <system:String x:Key="English">英语</system:String>
+    <system:String x:Key="French">法语</system:String>
+    <system:String x:Key="German">德语</system:String>
+    <system:String x:Key="Spanish">西班牙语</system:String>
+    <system:String x:Key="Japanese">日语</system:String>
+    <system:String x:Key="SimplifiedChinese">简体中文</system:String>
+
 
     <!--GameLauncher Strings-->
-    <system:String x:Key="CheckingFf7IsNotRunning">正在检查 FF7 是否未运行...</system:String>
-    <system:String x:Key="Ff7IsAlreadyRunning">FF7 已经运行!</system:String>
-    <system:String x:Key="Ff7IsAlreadyRunningDoYouWantToForceClose" xml:space="preserve">选择“是”，强制关闭正在后台运行的 FF7.exe 或 FF7_en.exe，然后你需要手动重新启动游戏。</system:String>
+    <system:String x:Key="CheckingFf7IsNotRunning">正在检查 FF7 是否已经运行 ...</system:String>
+    <system:String x:Key="Ff7IsAlreadyRunning">FF7 已经运行！</system:String>
+    <system:String x:Key="Ff7IsAlreadyRunningDoYouWantToForceClose" xml:space="preserve">FF7 已经运行！
+选择“是”，强制关闭正在后台运行的FF7，然后你需要手动重新启动游戏；
+选择“否”，继续打开一个新的FF7游戏进程。
+</system:String>
 
-    <system:String x:Key="ForceClosingAllInstancesFf7">正在强制关闭所有 FF7 ...</system:String>
-    <system:String x:Key="Aborting">正在中止...</system:String>
-    <system:String x:Key="FailedToCloseProcess">关闭进程失败</system:String>
-    <system:String x:Key="CheckingFf7ExeExistsAt">正在检查 FF7.exe 或 FF7_en.exe 是否存在于 </system:String>
-    <system:String x:Key="CheckingFF7SteamInstalledCorrectly">正在检查 FF7 Steam 版 是否正确安装...</system:String>
-    <system:String x:Key="FF7SteamNotInstalledCorrectly" xml:space="preserve">并未检测到你的 “文档\Square Enix\FINAL FANTASY VII Steam” 文件夹里存在用户配置文件。请确保你在使用 7th Heaven 之前，已经运行过一次 FF7 Steam 英文原版。
+    <system:String x:Key="ForceClosingAllInstancesFf7">正在强制关闭所有FF7进程...</system:String>
+    <system:String x:Key="Aborting">出现异常 ...</system:String>
+    <system:String x:Key="FailedToCloseProcess">进程关闭失败</system:String>
+    <system:String x:Key="CheckingFf7ExeExistsAt">正在检查 FF7.exe 或 FF7_en.exe 是否存在于</system:String>
+    <system:String x:Key="CheckingFF7SteamInstalledCorrectly">正在检查 FF7 Steam版是否已经正确安装...</system:String>
+    <system:String x:Key="FF7SteamNotInstalledCorrectly" xml:space="preserve">并未检测到你的“文档\Square Enix\FINAL FANTASY VII Steam”文件夹里存在用户配置文件。请确保你在使用第七天堂之前，已经运行过一次 FF7 Steam英文原版。
         
 接下来将会以英文状态启动游戏，请在弹出的英文窗口中点击Play，进入一次原版游戏，直到进入游戏主标题画面，确保电脑上的用户配置文件已经生成。
     
-然后按键盘Ctrl+Q 退出原版游戏，重新启动 7th Heaven ，再左上角按钮启动游戏。</system:String>
-    <system:String x:Key="FileNotFoundAborting">找不到文件。正在中止...</system:String>
-    <system:String x:Key="Ff7ExeNotFoundYouMayNeedToConfigure">找不到 FF7.exe 或 FF7_en.exe。您可能需要使用设置>常规设置菜单配置 7H。</system:String>
-    <system:String x:Key="VerifyingInstalledGameIsCompatible">正在验证安装的游戏是否兼容...</system:String>
-    <system:String x:Key="ErrorCodeYarr">错误代码：YARR! 无法继续。请在 Qhimm 论坛报告此错误。</system:String>
-    <system:String x:Key="VerifyingGameIsNotInstalledInProtectedFolder">正在验证游戏是否未安装在系统/受保护文件夹中...</system:String>
+然后按键盘Ctrl+Q 退出原版游戏，重新启动第七天堂，再点击左上角按钮启动游戏。</system:String>
+    <system:String x:Key="FileNotFoundAborting">文件丢失，出现异常 ...</system:String>
+    <system:String x:Key="Ff7ExeNotFoundYouMayNeedToConfigure">未找到 FF7.exe 或 FF7_en.exe，请检查“常规设置”中的FF7 exe文件所在路径。</system:String>
+    <system:String x:Key="VerifyingInstalledGameIsCompatible">正在验证安装的游戏是否兼容 ...</system:String>
+    <system:String x:Key="ErrorCodeYarr">游戏文件不完整，请回到Steam游戏库，验证FF7游戏文件的完整性，修复缺失的文件。或使用光盘重新安装游戏。</system:String>
+    <system:String x:Key="VerifyingGameIsNotInstalledInProtectedFolder">正在验证游戏是否被安装到了系统文件夹/受保护的文件夹 ...</system:String>
 
-    <system:String x:Key="Ff7IsCurrentlyInstalledInASystemFolder" xml:space="preserve">FF7 当前安装在系统文件夹中，可能导致模组无法工作。建议您将其安装在 C:\Games\Final Fantasy VII
+    <system:String x:Key="Ff7IsCurrentlyInstalledInASystemFolder" xml:space="preserve">FF7被安装到了系统文件夹/受保护的文件夹，任何包含“Program”文件名的文件夹都会导致模组无法加载。
 
-您想自动将安装复制到 C:\Games\Final Fantasy VII 以继续吗?</system:String>
+对于Steam版用户，请点击“否”，然后自己手动将Steam游戏库移动到没有“Program”文件名的文件夹。
 
-    <system:String x:Key="CanNotContinueDueToFf7nstalledInProtectedFolder">无法继续，因为 FF7 安装在系统/受保护文件夹中。正在中止...</system:String>
+对于1998光盘版用户，可以点击“是”，自动把游戏本体移动到 C:\Games\Final Fantasy VII 文件夹。</system:String>
+
+    <system:String x:Key="CanNotContinueDueToFf7nstalledInProtectedFolder">由于FF7被安装到了系统文件夹/受保护的文件夹，无法进行下一步。正在中止...</system:String>
     <system:String x:Key="CannotContinue">无法继续！</system:String>
 
-    <system:String x:Key="CopyingGameFilesTo">正在将游戏文件复制到以下地址：</system:String>
-    <system:String x:Key="FailedToCopyFf7To">复制 FF7 到以下地址失败：</system:String>
+    <system:String x:Key="CopyingGameFilesTo">正在将游戏文件复制到</system:String>
+    <system:String x:Key="FailedToCopyFf7To">无法将FF7复制到</system:String>
 
-    <system:String x:Key="VerifyingGameIsMaxInstall">正在验证游戏是否是完整/最大安装 ...</system:String>
-    <system:String x:Key="YourFf7InstallationFolderIsMissingCriticalFiles" xml:space="preserve">您的FF7安装文件夹缺少关键文件。安装时可能误选了"标准安装"，但需要"完整安装"。
+    <system:String x:Key="VerifyingGameIsMaxInstall">正在验证游戏是否完整/最大安装 ...</system:String>
+    <system:String x:Key="YourFf7InstallationFolderIsMissingCriticalFiles" xml:space="preserve">你的FF7安装文件夹缺少关键文件。在安装FF7 1998版时，你可能误选了“标准安装”，但“最大安装”是必需的。
 
-7th Heaven可自动修复此问题。只需插入任意游戏光盘后重试。</system:String>
+第七天堂可以自动修复此问题。只需插入游戏光盘并重试即可。</system:String>
 
-    <system:String x:Key="CreatingMissingRequiredDirectories">正在创建缺失的必要目录...</system:String>
-    <system:String x:Key="VerifyingAdditionalFilesForBattleAndKernelFoldersExist">正在验证 'battle' 和 'kernel' 文件夹的附加文件...</system:String>
-    <system:String x:Key="FailedToVerifyCopyMissingAdditionalFiles">验证/复制缺失附加文件失败。正在中止...</system:String>
+    <system:String x:Key="CreatingMissingRequiredDirectories">正在创建缺失的必要目录 ...</system:String>
+    <system:String x:Key="VerifyingAdditionalFilesForBattleAndKernelFoldersExist">正在验证“battle”和“kernel”文件夹的附加文件是否存在 ...</system:String>
+    <system:String x:Key="FailedToVerifyCopyMissingAdditionalFiles">验证/复制缺失的附加文件失败。正在中止...</system:String>
 
-    <system:String x:Key="VerifyingAllMovieFilesExist">正在验证所有过场动画文件...</system:String>
-    <system:String x:Key="CouldNotFindAllMovieFilesAt">无法在以下位置找到所有过场动画文件：</system:String>
-    <system:String x:Key="AllFilesFoundAt">所有文件已在以下位置找到：</system:String>
-    <system:String x:Key="UpdatingMoviePathSetting">正在更新过场动画路径设置。</system:String>
-    <system:String x:Key="AttemptingToCopyMovieFiles">正在尝试复制过场动画文件...</system:String>
+    <system:String x:Key="VerifyingAllMovieFilesExist">正在验证所有过场动画文件是否存在 ...</system:String>
+    <system:String x:Key="CouldNotFindAllMovieFilesAt">无法在以下位置找到所有过场动画文件: </system:String>
+    <system:String x:Key="AllFilesFoundAt">所有文件已在以下位置找到: </system:String>
+    <system:String x:Key="UpdatingMoviePathSetting">正在更新 过场动画movie文件夹路径设置</system:String>
+    <system:String x:Key="AttemptingToCopyMovieFiles">正在尝试复制过场动画文件 ...</system:String>
 
-    <system:String x:Key="MovieFilesAreMissing">过场动画文件缺失！</system:String>
-    <system:String x:Key="InOrderToSeeInGameMoviesYouWillNeedMessage" xml:space="preserve">要观看游戏内过场动画，您需要下载并激活过场动画模组。
+    <system:String x:Key="MovieFilesAreMissing">过场动画文件丢失！</system:String>
+    <system:String x:Key="InOrderToSeeInGameMoviesYouWillNeedMessage" xml:space="preserve">为了在游戏中正常播放过场动画，你需要下载并启用一个过场动画模组。
 
-或者，您可以通过设置>游戏启动器>从光盘导入过场动画。
+或者打开“工具 → 过场动画导入工具”，从FF7光盘中提取过场动画文件，导入到游戏文件夹中。</system:String>
 
-最后，您可以在"常规设置"中将过场动画路径指向光盘的 FF7\Movies 文件夹，但您必须在游戏时进行光盘更换。</system:String>
+    <system:String x:Key="VerifyingMusicFilesExist">正在验证音乐文件是否存在 ...</system:String>
+    <system:String x:Key="CouldNotFindAllMusicFilesAt">无法在以下位置找到所有音乐文件: </system:String>
+    <system:String x:Key="AttemptingToCopyMusicFiles">正在尝试复制音乐文件 ...</system:String>
 
-    <system:String x:Key="VerifyingMusicFilesExist">正在验证音乐文件...</system:String>
-    <system:String x:Key="CouldNotFindAllMusicFilesAt">无法在以下位置找到所有音乐文件：</system:String>
-    <system:String x:Key="AttemptingToCopyMusicFiles">正在尝试复制音乐文件...</system:String>
+    <system:String x:Key="OggMusicFilesAreMissing">.OGG 音乐文件缺失！</system:String>
+    <system:String x:Key="InOrderToHearHighQualityMusicYouWillNeedMessage" xml:space="preserve">为了听到高质量的背景音乐，你需要下载并启用一个音乐模组。
 
-    <system:String x:Key="OggMusicFilesAreMissing">OGG 音乐文件缺失！</system:String>
-    <system:String x:Key="InOrderToHearHighQualityMusicYouWillNeedMessage" xml:space="preserve">要获得高质量背景音乐，您需要下载并激活音乐模组。
+如果你想要体验原始MIDI音乐，可以考虑“在线模组目录”中的“FFNx FF7Music”模组。</system:String>
 
-或者，您可以收听游戏正版的低质量的 MIDI 音乐，但您需要在"音乐选项"选择"原始 MIDI"，该选项可在"设置">"游戏驱动程序...">"高级"选项卡。
+    <system:String x:Key="VerifyingLatestGameDriverIsInstalled">正在验证是否安装了最新的游戏驱动 ...</system:String>
+    <system:String x:Key="SomethingWentWrongTryingToDetectGameDriver">尝试检测/安装游戏驱动时出错。正在中止 ...</system:String>
+    <system:String x:Key="VerifyingGameDriverShadersFoldersExist">正在验证游戏驱动的着色器文件夹是否存在 ...</system:String>
 
-之后，如果您希望使用高质量 .OGG 文件，可通过设置回 'VGMstream' 恢复。</system:String>
+    <system:String x:Key="VerifyingFf7Exe">正在验证 ff7 exe ...</system:String>
+    <system:String x:Key="VerifyingFf7LauncherExe">正在验证 FF7_Launcher exe ...</system:String>
+    <system:String x:Key="Ff7ExeDetectedToBeDifferent">检测到 ff7.exe 不同。正在创建备份并复制正确的.exe ...</system:String>
+    <system:String x:Key="FailedToCopyFf7Exe">ff7.exe 复制失败。正在中止 ...</system:String>
+    <system:String x:Key="FailedToCreateBackupOfFf7Exe">无法创建 ff7.exe 的备份。正在中止 ...</system:String>
 
-    <system:String x:Key="VerifyingLatestGameDriverIsInstalled">正在验证最新游戏驱动...</system:String>
-    <system:String x:Key="SomethingWentWrongTryingToDetectGameDriver">检测/安装游戏驱动时出错。正在中止...</system:String>
-    <system:String x:Key="VerifyingGameDriverShadersFoldersExist">正在验证游戏驱动着色器文件夹...</system:String>
+    <system:String x:Key="Ff7ConfigExeDetectedToBeMissingOrDifferent">FF7Config.exe 缺失或检测到不同。正在创建备份（如果存在）并复制正确的.exe ...</system:String>
+    <system:String x:Key="FailedToCopyFf7ConfigExe">FF7Config.exe 复制失败。正在中止 ...</system:String>
+    <system:String x:Key="FailedToCreateBackupOfFf7ConfigExe">无法创建 FF7Config.exe 的备份。正在中止 ...</system:String>
 
-    <system:String x:Key="VerifyingFf7Exe">正在验证 ff7.exe...</system:String>
-    <system:String x:Key="VerifyingFf7LauncherExe">正在验证 FF7_Launcher.exe...</system:String>
-    <system:String x:Key="Ff7ExeDetectedToBeDifferent">检测到 ff7.exe 不一致。正在创建备份并复制正确版本...</system:String>
-    <system:String x:Key="FailedToCopyFf7Exe">复制 ff7.exe 失败。正在中止...</system:String>
-    <system:String x:Key="FailedToCreateBackupOfFf7Exe">创建 ff7.exe 备份失败。正在中止...</system:String>
+    <system:String x:Key="CheckingAProfileIsActive">正在检查是否有正在使用的预设文件 ...</system:String>
+    <system:String x:Key="ActiveProfileNotFound">找不到正在使用的预设文件。正在中止 ...</system:String>
+    <system:String x:Key="CreateAProfileFirstAndTryAgain">请先在“设置 → 预设”里创建一个预设文件，然后重试。</system:String>
 
-    <system:String x:Key="Ff7ConfigExeDetectedToBeMissingOrDifferent">FF7Config.exe 缺失或不一致。正在创建备份(如存在)并复制正确版本...</system:String>
-    <system:String x:Key="FailedToCopyFf7ConfigExe">复制 FF7Config.exe 失败。正在中止...</system:String>
-    <system:String x:Key="FailedToCreateBackupOfFf7ConfigExe">创建 FF7Config.exe 备份失败。正在中止...</system:String>
+    <system:String x:Key="CheckingModCompatibilityRequirements">正在检查模组兼容的要求 ...</system:String>
+    <system:String x:Key="FailedModCompatibilityCheck">模组兼容检查失败。正在中止 ...</system:String>
 
-    <system:String x:Key="CheckingAProfileIsActive">正在检查活动配置文件...</system:String>
-    <system:String x:Key="ActiveProfileNotFound">未找到活动配置文件。正在中止...</system:String>
-    <system:String x:Key="CreateAProfileFirstAndTryAgain">请先在设置>配置文件中创建配置文件>Profiles and try again.</system:String>
+    <system:String x:Key="CheckingModConstraintsForCompatibility">正在检查模组兼容规则 ...</system:String>
+    <system:String x:Key="FailedModConstraintCheck">模组兼容规则检查失败。正在中止 ...</system:String>
 
-    <system:String x:Key="CheckingModCompatibilityRequirements">正在检查模组兼容性需求...</system:String>
-    <system:String x:Key="FailedModCompatibilityCheck">模组兼容性检查失败。正在中止...</system:String>
+    <system:String x:Key="CheckingModLoadOrderRequirements">正在检查模组加载顺序的要求 ...</system:String>
+    <system:String x:Key="FailedModLoadOrderCheck">模组加载顺序检查失败。正在中止 ...</system:String>
 
-    <system:String x:Key="CheckingModConstraintsForCompatibility">正在检查模组约束兼容性...</system:String>
-    <system:String x:Key="FailedModConstraintCheck">模组约束检查失败。正在中止...</system:String>
+    <system:String x:Key="LookingForGameDisc">正在寻找游戏光盘 ...</system:String>
+    <system:String x:Key="FoundGameDiscAt">已在以下位置找到游戏光盘: </system:String>
+    <system:String x:Key="FailedToFindGameDisc">无法找到游戏光盘 ...</system:String>
+    <system:String x:Key="OsDoesNotSupportAutoMounting">操作系统不支持自动挂载虚拟光驱。必须挂载一个名为 FF7DISC1.ISO 的虚拟光驱，或插入一个名为 FF7DISC1 的U盘，或将一个硬盘驱动器重命名为 FF7DISC1 ...</system:String>
+    <system:String x:Key="AutoMountingVirtualGameDisc">正在自动挂载虚拟游戏光驱 ...</system:String>
+    <system:String x:Key="FailedToAutoMountVirtualDiscAt">无法在以下位置自动挂载虚拟光驱: </system:String>
+    <system:String x:Key="LookingForGameDiscAfterMounting">已挂载，正在寻找游戏光盘 ...</system:String>
+    <system:String x:Key="FailedToFindGameDiscAfterAutoMounting">自动挂载后无法找到游戏光盘 ...</system:String>
 
-    <system:String x:Key="CheckingModLoadOrderRequirements">正在检查模组加载顺序需求...</system:String>
-    <system:String x:Key="FailedModLoadOrderCheck">模组加载顺序检查失败。正在中止...</system:String>
+    <system:String x:Key="UserRequestedToPlayWithNoModsLaunchingGameAsVanilla">用户请求无模组游玩。正在以“原版”模式启动游戏 ...</system:String>
+    <system:String x:Key="NoModsActivatedLaunchingGameAsVanilla">没有开启任何模组。正在以“原版”模式启动游戏 ...</system:String>
+    <system:String x:Key="SelectedRendererIsNotSetToCustomLaunchingGameAsVanilla">选择的渲染器未设置为“自定义第七天堂游戏驱动”。正在以“原版”模式启动游戏 ...</system:String>
 
-    <system:String x:Key="LookingForGameDisc">正在查找游戏光盘...</system:String>
-    <system:String x:Key="FoundGameDiscAt">已在以下位置找到游戏光盘：</system:String>
-    <system:String x:Key="FailedToFindGameDisc">找不到游戏光盘...</system:String>
-    <system:String x:Key="OsDoesNotSupportAutoMounting">操作系统不支持自动挂载虚拟光盘。您需要挂载名为 FF7DISC1.ISO 的虚拟光盘，插入名为 FF7DISC1 的U盘或将硬盘重命名为 FF7DISC1 ...</system:String>
-    <system:String x:Key="AutoMountingVirtualGameDisc">正在自动挂载虚拟游戏光盘...</system:String>
-    <system:String x:Key="FailedToAutoMountVirtualDiscAt">自动挂载虚拟光盘到以下地址失败：</system:String>
-    <system:String x:Key="LookingForGameDiscAfterMounting">挂载后正在查找游戏光盘...</system:String>
-    <system:String x:Key="FailedToFindGameDiscAfterAutoMounting">自动挂载后查找游戏光盘失败...</system:String>
+    <system:String x:Key="CreatingRuntimeProfile">正在创建 Runtime配置文件 ...</system:String>
+    <system:String x:Key="FailedToCreateRuntimeProfileForActiveMods">无法为已开启的模组创建Runtime配置文件 ...</system:String>
 
-    <system:String x:Key="UserRequestedToPlayWithNoModsLaunchingGameAsVanilla">用户要求无模组启动。正在以纯净模式运行游戏...</system:String>
-    <system:String x:Key="NoModsActivatedLaunchingGameAsVanilla">未激活任何模组。正在以纯净模式运行游戏...</system:String>
-    <system:String x:Key="SelectedRendererIsNotSetToCustomLaunchingGameAsVanilla">渲染器未设置为'自定义 7H 游戏驱动'。正在以纯净模式运行游戏...</system:String>
+    <system:String x:Key="VariableDumpSetToTrueStartingTurboLog">变量转储设置为 true。正在启动 TurBoLog ...</system:String>
+    <system:String x:Key="CopyingEasyHookToFf7PathIfNotFoundOrOlder">正在将 AppLoader.dll 复制到 FF7 路径（如果未找到或检测到旧版本） ...</system:String>
 
-    <system:String x:Key="CreatingRuntimeProfile">正在创建运行时配置文件...</system:String>
-    <system:String x:Key="FailedToCreateRuntimeProfileForActiveMods">为活动模组创建运行时配置文件失败...</system:String>
+    <system:String x:Key="CopyingFf7InputCfgToFf7Path">正在将 ff7input.cfg 复制到FF7文件夹 ...</system:String>
+    <system:String x:Key="DebugLoggingSetToTrueDetailedLoggingWillBeWrittenTo">调试日志设置为 true。详细日志将写入: </system:String>
 
-    <system:String x:Key="VariableDumpSetToTrueStartingTurboLog">变量转储已启用。正在启动 TurBoLog...</system:String>
-    <system:String x:Key="CopyingEasyHookToFf7PathIfNotFoundOrOlder">正在复制 AppLoader.dll 到 FF7 路径(如未找到或版本较旧)...</system:String>
+    <system:String x:Key="CheckingIfReunionModIsInstalled">正在检查是否安装了 Reunion模组 ...</system:String>
+    <system:String x:Key="Found">已找到</system:String>
+    <system:String x:Key="DisablingReunionMod">正在禁用 Reunion模组 (将 ddraw.dll 重命名为 Reunion.dll.bak) ...</system:String>
+    <system:String x:Key="ReenablingReunionMod">正在重新启用 Reunion模组 (将 Reunion.dll.bak 重命名为 ddraw.dll) ...</system:String>
 
-    <system:String x:Key="CopyingFf7InputCfgToFf7Path">正在复制 ff7input.cfg 到 FF7 路径...</system:String>
-    <system:String x:Key="DebugLoggingSetToTrueDetailedLoggingWillBeWrittenTo">调试日志已启用。详细日志将写入到：</system:String>
+    <system:String x:Key="LaunchingAdditionalProgramsToRunIfAny">正在启动要运行的附加程序 (如果有) ...</system:String>
+    <system:String x:Key="WritingTemporaryRuntimeProfileFileTo">正在将临时Runtime配置文件写入</system:String>
 
-    <system:String x:Key="CheckingIfReunionModIsInstalled">正在检查是否安装 Reunion 模组...</system:String>
-    <system:String x:Key="Found">查找到</system:String>
-    <system:String x:Key="DisablingReunionMod">正在禁用 Reunion 模组（重命名 ddraw.dll 为 Reunion.dll.bak）...</system:String>
-    <system:String x:Key="ReenablingReunionMod">正在重新启用 Reunion 模组（重命名 ddraw.dll 为 Reunion.dll.bak）...</system:String>
+    <system:String x:Key="AttemptingToInjectWithEasyHook">正在尝试通过 AppLoader 注入 ...</system:String>
+    <system:String x:Key="ReceivedErrors">收到报错</system:String>
+    <system:String x:Key="ReachedTimeoutWaitingForInjection">等待注入已超时 ...</system:String>
+    <system:String x:Key="ReceivedUnknownError">收到未知报错</system:String>
+    <system:String x:Key="FailedToInjectAfterMaxAmountOfTries">在最大尝试次数之后，仍然无法注入</system:String>
 
-    <system:String x:Key="LaunchingAdditionalProgramsToRunIfAny">正在启动需要运行的附加程序(如有)...</system:String>
-    <system:String x:Key="WritingTemporaryRuntimeProfileFileTo">正在将临时运行时配置文件写入到：</system:String>
+    <system:String x:Key="ErrorFailedToStartGame">出错 - 游戏启动失败</system:String>
+    <system:String x:Key="FailedToInjectWithEasyHookMessage" xml:space="preserve">多次尝试之后，仍然无法通过 AppLoader 注入。通常的解决方法是在游戏启动器设置里将“Code 5 Fix”设置为“On”。
 
-    <system:String x:Key="AttemptingToInjectWithEasyHook">正在尝试通过 AppLoader 注入...</system:String>
-    <system:String x:Key="ReceivedErrors">收到错误</system:String>
-    <system:String x:Key="ReachedTimeoutWaitingForInjection">等待注入超时...</system:String>
-    <system:String x:Key="ReceivedUnknownError">收到未知错误</system:String>
-    <system:String x:Key="FailedToInjectAfterMaxAmountOfTries">尝试最大次数后仍注入失败</system:String>
+是否要应用此设置并重试？</system:String>
 
-    <system:String x:Key="ErrorFailedToStartGame">错误 - 启动游戏失败</system:String>
-    <system:String x:Key="FailedToInjectWithEasyHookMessage" xml:space="preserve">多次尝试后仍无法通过 AppLoader 注入。通常可通过在游戏启动器设置中启用'代码5修复'解决。
+    <system:String x:Key="SettingCompatibilityFixAndTryingAgain">正在设置兼容性修复并重试 ...</system:String>
+    <system:String x:Key="StillFailedToInjectWithEasyHookAborting">设置兼容性修复后仍然无法通过 AppLoader 注入。正在中止 ...</system:String>
+    <system:String x:Key="FailedToInjectWithEasyHookAfterSettingFlags">即使设置了兼容性标志，仍然无法通过 AppLoader 注入</system:String>
+    <system:String x:Key="UserChoseNotToSetCompatibilityFix">用户选择不设置兼容性修复。正在中止 ...</system:String>
 
-您想立即应用该设置并重试？</system:String>
+    <system:String x:Key="GettingFf7Proc">正在获取FF7进程 ...</system:String>
+    <system:String x:Key="FailedToGetFf7Proc">无法获取FF7进程。正在中止 ...</system:String>
+    <system:String x:Key="DebugLoggingSetToTrueWiringUpLogFile">调试日志设置为 true。正在设置“日志文件在游戏退出后打开” ...</system:String>
+    <system:String x:Key="FailedToStartProcessForDebugLog">无法启动调试日志的进程</system:String>
 
-    <system:String x:Key="SettingCompatibilityFixAndTryingAgain">正在设置兼容性修复并重试...</system:String>
-    <system:String x:Key="StillFailedToInjectWithEasyHookAborting">设置兼容性修复后仍注入失败。正在中止...</system:String>
-    <system:String x:Key="FailedToInjectWithEasyHookAfterSettingFlags">即使设置兼容性标志后仍注入失败</system:String>
-    <system:String x:Key="UserChoseNotToSetCompatibilityFix">用户选择不设置兼容性修复。正在中止...</system:String>
+    <system:String x:Key="StartingProgramsForMods">正在启动模组所需程序 ...</system:String>
+    <system:String x:Key="StartingPluginsForMods">正在启动模组所需插件 ...</system:String>
+    <system:String x:Key="SettingUpFf7ExeToStopPluginsAndModPrograms">正在设置 FF7.exe 在退出之后停止插件和模组程序 ...</system:String>
 
-    <system:String x:Key="GettingFf7Proc">正在获取 FF7 进程...</system:String>
-    <system:String x:Key="FailedToGetFf7Proc">获取 FF7 进程失败。正在中止...</system:String>
-    <system:String x:Key="DebugLoggingSetToTrueWiringUpLogFile">调试日志已启用。正在配置游戏退出后的日志文件...</system:String>
-    <system:String x:Key="FailedToStartProcessForDebugLog">启动调试日志进程失败</system:String>
+    <system:String x:Key="StoppingOtherProgramsForMods">正在停止由第七天堂启动的其它模组程序 ...</system:String>
+    <system:String x:Key="AutoUnmountingGameDisc">正在自动卸载游戏光盘 ...</system:String>
 
-    <system:String x:Key="StartingProgramsForMods">正在启动模组相关程序...</system:String>
-    <system:String x:Key="StartingPluginsForMods">正在启动模组插件...</system:String>
-    <system:String x:Key="SettingUpFf7ExeToStopPluginsAndModPrograms">正在配置 FF7.exe 在退出时停止插件和模组程序...</system:String>
+    <system:String x:Key="WaitingForFf7ExeToRespond">正在等待 FF7.exe 响应 (最多 {0} 秒) ...</system:String>
+    <system:String x:Key="ExceptionOccurredWhileTryingToStart">尝试启动FF7时发生异常 ...</system:String>
 
-    <system:String x:Key="StoppingOtherProgramsForMods">正在停止 7H 启动的模组相关程序...</system:String>
-    <system:String x:Key="AutoUnmountingGameDisc">正在自动卸载游戏光盘...</system:String>
-
-    <system:String x:Key="WaitingForFf7ExeToRespond">正在等待 FF7.exe 响应(最多{0}秒)...</system:String>
-    <system:String x:Key="ExceptionOccurredWhileTryingToStart">尝试启动 FF7 时发生异常...</system:String>
-
-    <system:String x:Key="PluginAdded">插件已新增</system:String>
+    <system:String x:Key="PluginAdded">插件已添加</system:String>
     <system:String x:Key="StartingPlugin">正在启动插件</system:String>
 
-    <system:String x:Key="FailedToGetListOfRuntimeMods">由于模组变量缺失，无法获取运行时模组列表</system:String>
-    <system:String x:Key="AddingPathsToMonitor">正在新增监控路径...</system:String>
+    <system:String x:Key="FailedToGetListOfRuntimeMods">由于一个缺失的模组变量，无法获取 Runtime模组列表</system:String>
+    <system:String x:Key="AddingPathsToMonitor">正在添加需要读取的路径 ...</system:String>
 
-    <system:String x:Key="DetectedToBeOlderVersion">检测到旧版本</system:String>
-    <system:String x:Key="Copied">复制</system:String>
-    <system:String x:Key="SkippedCopying">跳过复制</system:String>
+    <system:String x:Key="DetectedToBeOlderVersion">检测到是旧版本</system:String>
+    <system:String x:Key="Copied">已复制</system:String>
+    <system:String x:Key="SkippedCopying">已跳过复制</system:String>
 
-    <system:String x:Key="AnExceptionOccurredTryingToStartFf7At">以下地址在尝试启动 FF7 时发生异常：</system:String>
+    <system:String x:Key="AnExceptionOccurredTryingToStartFf7At">尝试启动FF7时出现以下异常: </system:String>
 
-    <system:String x:Key="ThereWasAnErrorVerifyingModConstraintSeeTheFollowingDetails">验证模组约束时出错。详情如下：</system:String>
-    <system:String x:Key="TheFollowingSettingsHaveBeenChangedToMakeTheseModsCompatible">为了保证模组之间的兼容，以下设置已经自动调整：</system:String>
+    <system:String x:Key="ThereWasAnErrorVerifyingModConstraintSeeTheFollowingDetails">验证模组兼容规则时出错。详情如下:</system:String>
+    <system:String x:Key="TheFollowingSettingsHaveBeenChangedToMakeTheseModsCompatible">为了保证模组之间的兼容，以下设置已经自动调整:</system:String>
 
 
-    <system:String x:Key="ModRequiresYouToActivateAsWell">模组 {0} 要求您同时激活 {1}</system:String>
-    <system:String x:Key="ModRequiresYouToActivateButYouDoNotHaveCompatibleVersionInstalled">模组 {0} 要求激活 {1}，但您安装的版本不兼容。请尝试更新？</system:String>
+    <system:String x:Key="ModRequiresYouToActivateAsWell">模组 {0} 需要同时开启 {1}</system:String>
+    <system:String x:Key="ModRequiresYouToActivateButYouDoNotHaveCompatibleVersionInstalled">模组 {0} 需要同时开启 {1}，但你并没有安装可以兼容的版本。尝试更新该模组？</system:String>
     <system:String x:Key="UnsupportedModVersion">不支持的模组版本</system:String>
 
-    <system:String x:Key="IncompatibleMod">不兼容模组</system:String>
-    <system:String x:Key="ModIsNotCompatibleWithTheVersionYouHaveInstalled">模组 {0} 与您安装的 {1} 版本不兼容。请尝试更新？</system:String>
-    <system:String x:Key="ModIsNotCompatibleWithYouWillNeedToDisableIt">模组 {0} 与 {1} 不兼容。您需要禁用其中一项。</system:String>
+    <system:String x:Key="IncompatibleMod">不兼容的模组</system:String>
+    <system:String x:Key="ModIsNotCompatibleWithTheVersionYouHaveInstalled">模组 {0} 不兼容你所安装的 {1} 的版本。尝试更新该模组？</system:String>
+    <system:String x:Key="ModIsNotCompatibleWithYouWillNeedToDisableIt">模组 {0} 不兼容 {1}。你需要禁用它。</system:String>
+    <system:String x:Key="ModIsNotCompatibleAnotherModVariableUsed">模组 {0} 不兼容 {1}，因为变量'{2}'在两个模组中同时存在。你需要禁用其中一个。</system:String>
 
-    <system:String x:Key="TheFollowingModsWillNotWorkProperlyInTheCurrentOrder">当前加载顺序下，以下模组可能无法正常工作，您无论如何都要继续吗？</system:String>
+    <system:String x:Key="TheFollowingModsWillNotWorkProperlyInTheCurrentOrder">以下模组在当前加载顺序下无法正常使用。仍要继续吗？</system:String>
     <system:String x:Key="LoadOrderIncompatible">加载顺序不兼容</system:String>
-    <system:String x:Key="ModIsMeantToComeBelowModInTheLoadOrder">模组 {0} 应位于模组 {1} 之后加载</system:String>
-    <system:String x:Key="ModIsMeantToComeAboveModInTheLoadOrder">模组 {0} 应位于模组 {1} 之前加载</system:String>
+    <system:String x:Key="ModIsMeantToComeBelowModInTheLoadOrder">模组 {0} 的加载顺序应该在 {1} 的下面。</system:String>
+    <system:String x:Key="ModIsMeantToComeAboveModInTheLoadOrder">模组 {0} 的加载顺序应该在 {1} 的上面。</system:String>
 
-    <system:String x:Key="CouldNotFindDdrawDllAt">以下地址找不到 ddraw.dll：</system:String>
-    <system:String x:Key="CouldNotFindReunionDllBakAt">以下地址找不到 Reunion.dll.bak：</system:String>
+    <system:String x:Key="CouldNotFindDdrawDllAt">ddraw.dll 无法在以下位置找到: </system:String>
+    <system:String x:Key="CouldNotFindReunionDllBakAt">Reunion.dll.bak 无法在以下位置找到: </system:String>
     <system:String x:Key="Renamed">已重命名</system:String>
 
-    <system:String x:Key="ApplyingChangedValuesToRegistry">正在应用注册表修改...</system:String>
-    <system:String x:Key="ApplyingCompatibilityFlagsInRegistry">正在应用注册表兼容性标志(如有)...</system:String>
-    <system:String x:Key="CompatibilityFlagsFoundDeleting">找到兼容性标志 - 正在删除</system:String>
-    <system:String x:Key="HighDpiFixSetToTrueApplyingCompatibilityFlag">高 DPI 修复已启用 - 正在应用 HIGHDPIAWARE 兼容性标志</system:String>
+    <system:String x:Key="ApplyingChangedValuesToRegistry">正在将更改的值应用到注册表 ...</system:String>
+    <system:String x:Key="ApplyingCompatibilityFlagsInRegistry">正在应用注册表中的兼容性标志 (如果有) ...</system:String>
+    <system:String x:Key="CompatibilityFlagsFoundDeleting">找到了兼容性标志 - 正在删除</system:String>
+    <system:String x:Key="HighDpiFixSetToTrueApplyingCompatibilityFlag">高DPI修复设置为 true - 正在注册表中应用 HIGHDPIAWARE 兼容性标志</system:String>
 
-    <system:String x:Key="UsingControlConfigurationFile">正在使用控制配置文件</system:String>
-    <system:String x:Key="InputCfgFileNotFoundAt">以下地址找不到输入配置文件：</system:String>
-    <system:String x:Key="FailedToCopyCfgFile">复制 .cfg 文件失败</system:String>
+    <system:String x:Key="UsingControlConfigurationFile">正在使用按键配置文件</system:String>
+    <system:String x:Key="InputCfgFileNotFoundAt">在以下位置找不到按键配置.cfg文件: </system:String>
+    <system:String x:Key="FailedToCopyCfgFile">无法复制按键配置.cfg文件</system:String>
 
     <system:String x:Key="StartingProgram">正在启动程序</system:String>
-    <system:String x:Key="Started">已启动...</system:String>
-    <system:String x:Key="WaitingForProgramToInitializeAndShow">等待程序初始化和显示...</system:String>
-    <system:String x:Key="TimeoutReachedWaitingForProgramToShow">等待程序显示超时({0}秒)。继续中...</system:String>
-    <system:String x:Key="ProgramAlreadyRunning">程序已在运行中</system:String>
+    <system:String x:Key="Started">已启动 ...</system:String>
+    <system:String x:Key="WaitingForProgramToInitializeAndShow">正在等待程序初始化并显示 ...</system:String>
+    <system:String x:Key="TimeoutReachedWaitingForProgramToShow">等待程序显示超时 ({0}秒)。正在继续...</system:String>
+    <system:String x:Key="ProgramAlreadyRunning">程序已经正在运行</system:String>
     
     
     
     
     <!--GameConverter Class Strings-->
-    <system:String x:Key="NotFoundScanningDiscsForFiles">未找到。正在扫描光盘查找文件...</system:String>
-    <system:String x:Key="FoundFileOnAtCopyingFile">在 {1} 找到 {0}。正在复制文件...</system:String>
+    <system:String x:Key="NotFoundScanningDiscsForFiles">未找到。正在扫描光盘以查找文件 ...</system:String>
+    <system:String x:Key="FoundFileOnAtCopyingFile">在 {0} 的 {1} 处找到文件。正在复制文件 ...</system:String>
     <system:String x:Key="FailedToCopyErrorHasBeenLogged">复制失败。错误已记录</system:String>
-    <system:String x:Key="FailedToFindOnAnyDisc">在任何光盘上都找不到 {0}...</system:String>
-    <system:String x:Key="FileNotFound">找不到文件...</system:String>
-    <system:String x:Key="CannotCopySourceFileBecauseItIsMissingAt">无法复制源文件，因为它在以下位置不存在：</system:String>
-    <system:String x:Key="CopyingFileFrom">从以下位置复制文件：</system:String>
+    <system:String x:Key="FailedToFindOnAnyDisc">无法在任何光盘上找到 {0} ...</system:String>
+    <system:String x:Key="FileNotFound">文件未找到...</system:String>
+    <system:String x:Key="CannotCopySourceFileBecauseItIsMissingAt">无法复制源文件，因为它在以下位置缺失: </system:String>
+    <system:String x:Key="CopyingFileFrom">正在从以下位置复制文件: </system:String>
 
-    <system:String x:Key="CannotCheckIfLatestDriverIsInstalledDueToMissingFile">由于缺少文件，无法检查是否安装了最新驱动</system:String>
-    <system:String x:Key="GameDriverDllFileIsUpToDate">7H_GameDriver.dll 文件是最新的。</system:String>
-    <system:String x:Key="BackingUpExistingGameDriverTo">正在备份现有游戏驱动到：</system:String>
-    <system:String x:Key="BackingUpExistingGameDriverCfgTo">正在备份现有游戏驱动 .cfg 到：</system:String>
-    <system:String x:Key="GameDriverCfgFileMissingCopyingDefaultFrom">7H_GameDriver.cfg 文件缺失。正在从以下位置复制默认文件：</system:String>
-    <system:String x:Key="CannotCreateDefaultCfgDueToMissingFile">由于缺少文件，无法创建默认 .cfg</system:String>
-    <system:String x:Key="BackingUpExistingShadersFolderTo">正在备份现有 'shaders' 文件夹到：</system:String>
-    <system:String x:Key="CopyingContentsOf">正在复制以下文件内容：</system:String>
-    <system:String x:Key="DirectoryMissingCreating">目录缺失。正在创建</system:String>
-    <system:String x:Key="OldGameConverterRegistryKeysFoundBackingUp">找到旧的 Game Converter 注册表键。正在备份旧转换器文件和注册表...</system:String>
+    <system:String x:Key="CannotCheckIfLatestDriverIsInstalledDueToMissingFile">由于文件缺失，无法检查是否安装了最新的驱动</system:String>
+    <system:String x:Key="GameDriverDllFileIsUpToDate">FFNx.dll文件是最新的。</system:String>
+    <system:String x:Key="BackingUpExistingGameDriverTo">正在将现有游戏驱动备份到</system:String>
+    <system:String x:Key="BackingUpExistingGameDriverCfgTo">正在将现有游戏驱动.cfg备份到</system:String>
+    <system:String x:Key="GameDriverCfgFileMissingCopyingDefaultFrom">FFNx.toml文件缺失。正在从以下位置复制默认文件: </system:String>
+    <system:String x:Key="CannotCreateDefaultCfgDueToMissingFile">由于文件缺失，无法创建默认.cfg</system:String>
+    <system:String x:Key="BackingUpExistingShadersFolderTo">正在将现有的“shaders”文件夹备份到</system:String>
+    <system:String x:Key="CopyingContentsOf">正在复制以下位置的内容: </system:String>
+    <system:String x:Key="DirectoryMissingCreating">文件夹缺失。正在创建</system:String>
+    <system:String x:Key="OldGameConverterRegistryKeysFoundBackingUp">找到了旧的游戏转换器注册表项。正在备份旧的转换器文件和注册表 ...</system:String>
 
-    <system:String x:Key="MissingShadersNolightFolderCreatingDirectory">缺少 shaders/nolight 文件夹。正在创建目录...</system:String>
-    <system:String x:Key="MissingShadersComplexMultiShaderFolderCreatingDirectory">缺少 shaders/ComplexMultiShader_Nvidia 文件夹。正在创建目录...</system:String>
-    <system:String x:Key="MissingShadersFolderCreatingDirectory">缺少 shaders 文件夹。正在从 Resources/Game Driver/ 复制...</system:String>
-    <system:String x:Key="MissingShadersFilesCopyingFrom">缺少着色器文件：{0}。从以下位置复制：{1} ...</system:String>
+    <system:String x:Key="MissingShadersNolightFolderCreatingDirectory">缺少 shaders/nolight文件夹。正在创建 ...</system:String>
+    <system:String x:Key="MissingShadersComplexMultiShaderFolderCreatingDirectory">缺少 shaders/ComplexMultiShader_Nvidia文件夹。正在创建 ...</system:String>
+    <system:String x:Key="MissingShadersFolderCreatingDirectory">缺少 shaders 文件夹。正在从 Resources/Game Driver/ 复制 ...</system:String>
+    <system:String x:Key="MissingShadersFilesCopyingFrom">缺少着色器文件: {0}。正在从 {1} 复制 ...</system:String>
     
     
     <!--UpdateChecker Class Strings-->
-    <system:String x:Key="CheckingForUpdatesAt">正在从以下位置检查更新：</system:String>
-    <system:String x:Key="FailedToCheckForUpdatesAt">从以下位置检查更新失败：</system:String>
+    <system:String x:Key="CheckingForUpdatesUsingChannel">检查更新</system:String>
+    <system:String x:Key="FailedToCheckForUpdatesAt">检查更新失败</system:String>
 
+    
+    
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/5/20-->
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/5/20-->
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/5/20-->
 
     <!--ConfigureGLWindow.xaml.cs Strings-->
-    <system:String x:Key="Graphics">图形</system:String>
+    <system:String x:Key="Graphics">画面</system:String>
     <system:String x:Key="Controls">控制</system:String>
-    <system:String x:Key="Cheats">快捷键</system:String>
     <system:String x:Key="Rendering">渲染</system:String>
+    <system:String x:Key="Cheats">快捷键</system:String>
     <system:String x:Key="Advanced">高级</system:String>
 
     <!--FileUtils.cs Strings-->
-    <system:String x:Key="FailedToCopyDirectory">复制目录失败</system:String>
-    <system:String x:Key="FailedToMoveDirectory">移动目录失败</system:String>
-    <system:String x:Key="FailedToDeleteFiles">删除文件失败</system:String>
+    <system:String x:Key="FailedToCopyDirectory">复制到文件夹失败</system:String>
+    <system:String x:Key="FailedToMoveDirectory">移动到文件夹失败</system:String>
+    <system:String x:Key="FailedToDeleteFiles">文件删除失败</system:String>
 
-    <system:String x:Key="FailedToGetPreviewImage">获取预览图像失败</system:String>
+    <system:String x:Key="FailedToGetPreviewImage">预览图片获取失败</system:String>
 
-    <system:String x:Key="ErrorOccurredDownloadingInstalling">下载/安装时发生错误</system:String>
+    <system:String x:Key="ErrorOccurredDownloadingInstalling">下载/安装时出错</system:String>
 
     <system:String x:Key="Installed">已安装</system:String>
-    <system:String x:Key="Updated">已更新</system:String>
-    <system:String x:Key="ErrorUpdating">更新时出错</system:String>
+    <system:String x:Key="Updated">已升级</system:String>
+    <system:String x:Key="ErrorUpdating">升级失败</system:String>
 
-    <system:String x:Key="FailedToGetModInfoDueToMissingVariable">警告:由于缺少变量，无法获取模组信息，可能导致问题</system:String>
+    <system:String x:Key="FailedToGetModInfoDueToMissingVariable">警告: 由于缺少一个变量，导致无法获取模组信息，这可能会引发问题。</system:String>
 
-    <system:String x:Key="TheFollowingModsWereNotFoundInstalledAndHaveBeenRemoved">下模组未找到安装，已从配置文件中删除</system:String>
-    <system:String x:Key="ErrorLoadingSettingsPleaseConfigure7H">加载设置错误 - 请使用设置>常规设置...菜单配置 7H</system:String>
-    <system:String x:Key="ErrorLoadingLibraryFile">加载库文件错误</system:String>
+    <system:String x:Key="TheFollowingModsWereNotFoundInstalledAndHaveBeenRemoved">找不到以下模组的安装信息，已从配置文件中移除。</system:String>
+    <system:String x:Key="ErrorLoadingSettingsPleaseConfigure7H">无法加载设置 - 请打开“设置 → 常规设置”菜单重新配置选项。</system:String>
+    <system:String x:Key="ErrorLoadingLibraryFile">无法加载存放模组的文件夹</system:String>
     <system:String x:Key="FailedToImportMod">导入模组失败</system:String>
-    <system:String x:Key="AutoImportedMod">自动导入模组</system:String>
-    <system:String x:Key="CouldNotImportIroFileIsCorrupt">无法导入 .iro 模组，文件已损坏</system:String>
-    <system:String x:Key="ModCouldNotBeFoundHasItBeenDeleted">找不到模组。是否已被删除？已从列表中删除。</system:String>
+    <system:String x:Key="AutoImportedMod">已自动导入模组</system:String>
+    <system:String x:Key="CouldNotImportIroFileIsCorrupt">.iro文件已损坏，无法导入，请重新下载。</system:String>
+    <system:String x:Key="ModCouldNotBeFoundHasItBeenDeleted">模组已丢失，请从列表中删除。</system:String>
 
-    <system:String x:Key="CouldNotLoadProfile">无法加载配置文件</system:String>
+    <system:String x:Key="CouldNotLoadProfile">无法加载预设</system:String>
 
-    <system:String x:Key="FailedToPackIntoIro">打包到 .iro 失败</system:String>
-    <system:String x:Key="PackingIntoIro">正在将 {0} 打包到 .iro...</system:String>
-    <system:String x:Key="UnpackingIroIntoSubfolder">正在将 {0}.iro 解包到子文件夹 '{0}'...</system:String>
-    <system:String x:Key="FailedToUnpackIro">解包 .iro 失败</system:String>
+    <system:String x:Key="FailedToPackIntoIro">打包.iro 失败</system:String>
+    <system:String x:Key="PackingIntoIro">正在将 {0} 打包成.iro ...</system:String>
+    <system:String x:Key="UnpackingIroIntoSubfolder">正在将 {0}.iro 解包到 '{0}' 子文件夹...</system:String>
+    <system:String x:Key="FailedToUnpackIro">解包.iro 失败</system:String>
 
-    <system:String x:Key="SelectModToDownloadFirst">请先选择要下载的模组。</system:String>
-    <system:String x:Key="NoDownloadSelected">未选择下载。</system:String>
-    <system:String x:Key="SelectAModFirst">请先选择模组。</system:String>
+    <system:String x:Key="SelectModToDownloadFirst">先选择一个要下载模组。</system:String>
+    <system:String x:Key="NoDownloadSelected">没有选择要下载的内容。</system:String>
+    <system:String x:Key="SelectAModFirst">先选择一个模组。</system:String>
 
-    <system:String x:Key="FailedToSaveCatalogXml">保存 catalog.xml 失败</system:String>
+    <system:String x:Key="FailedToSaveCatalogXml">目录xml保存失败</system:String>
 
-    <system:String x:Key="ModNotActiveOnlyActivatedModsCanBeConfigured">模组未激活。只有已激活的模组可以配置。</system:String>
+    <system:String x:Key="ModNotActiveOnlyActivatedModsCanBeConfigured">模组未开启。先开启，再自定义配置。</system:String>
 
     <system:String x:Key="UninstallWarning">卸载警告</system:String>
-    <system:String x:Key="AreYouSureYouWantToDelete">您确定要删除 </system:String>
-
-
+    <system:String x:Key="AreYouSureYouWantToDelete">你确定要删除</system:String>
+    
+    
     <!--ThemeSettingsWindow Strings-->
-    <system:String x:Key="ColorTheme">颜色主题：</system:String>
-    <system:String x:Key="AppBackground">应用背景：</system:String>
-    <system:String x:Key="SecondaryBackground">次要背景：</system:String>
-    <system:String x:Key="ControlsDisabledBackground">控件禁用背景：</system:String>
-    <system:String x:Key="ControlsDisabledForeground">控件禁用前景：</system:String>
-    <system:String x:Key="BackgroundImage">背景图片：</system:String>
-    <system:String x:Key="ControlsBackground">控件背景：</system:String>
-    <system:String x:Key="ControlsForeground">控件前景：</system:String>
-    <system:String x:Key="ControlsMouseOver">鼠标悬停控件:</system:String>
-    <system:String x:Key="ControlsPressed">按下控件：</system:String>
-    <system:String x:Key="ImportTheme">导入主题</system:String>
+    <system:String x:Key="ColorTheme">配色主题:</system:String>
+    <system:String x:Key="AppBackground">底层背景色:</system:String>
+    <system:String x:Key="SecondaryBackground">上层背景色:</system:String>
+    <system:String x:Key="ControlsDisabledBackground">二级按钮颜色:</system:String>
+    <system:String x:Key="ControlsDisabledForeground">二级字体颜色:</system:String>
+    <system:String x:Key="BackgroundImage">背景图片:</system:String>
+    <system:String x:Key="BackgroundHorizontalAlignment">背景图水平对齐:</system:String>
+    <system:String x:Key="BackgroundVerticalAlignment">背景图垂直对齐:</system:String>
+    <system:String x:Key="BackgroundStretch">背景图拉伸:</system:String>
+    <system:String x:Key="ControlsBackground">按钮颜色:</system:String>
+    <system:String x:Key="ControlsForeground">字体颜色:</system:String>
+    <system:String x:Key="ControlsSecondary">鼠标点击链接时的背景色:</system:String>
+    <system:String x:Key="ControlsMouseOver">鼠标滑过时的背景色:</system:String>
+    <system:String x:Key="ControlsPressed">所选内容的背景色:</system:String>
+    <system:String x:Key="ImportTheme">导入主题预设</system:String>
 
 
 
     <!--PackIroUserControl Strings-->
     <system:String x:Key="SourceFolder">源文件夹:</system:String>
-    <system:String x:Key="SaveAsIro">另存为 IRO：</system:String>
-    <system:String x:Key="SaveAsIrop">另存为 IROP：</system:String>
-    <system:String x:Key="Compress">压缩：</system:String>
-    <system:String x:Key="FilesToDelete">要删除的文件：</system:String>
-    <system:String x:Key="NewIro">新 IRO：</system:String>
-    <system:String x:Key="OriginalIro">原始 IRO：</system:String>
-    <system:String x:Key="SourceIro">源 IRO：</system:String>
+    <system:String x:Key="SaveAsIro">另存为IRO:</system:String>
+    <system:String x:Key="SaveAsIrop">另存为IROP:</system:String>
+    <system:String x:Key="Compress">压缩:</system:String>
+    <system:String x:Key="FilesToDelete">要删除的文件:</system:String>
+    <system:String x:Key="NewIro">新的IRO:</system:String>
+    <system:String x:Key="OriginalIro">原本的IRO:</system:String>
+    <system:String x:Key="SourceIro">IRO源文件:</system:String>
 
     <!--CreateModUserControl Strings-->
-    <system:String x:Key="OuputsCurrentModXmlToBelow">将当前 mod.xml 输出到下方文本区域。</system:String>
-    <system:String x:Key="SaveModXmlToFile">将 mod.xml 保存到文件</system:String>
-    <system:String x:Key="LoadModXmlFileToEdit">加载 mod.xml 文件进行编辑</system:String>
+    <system:String x:Key="OutputsCurrentModXmlToBelow">将当前 mod.xml 输出到下方文本区域。</system:String>
+    <system:String x:Key="SaveModXmlToFile">保存 mod.xml文件</system:String>
+    <system:String x:Key="LoadModXmlFileToEdit">加载一个 mod.xml文件并进行编辑</system:String>
 
     <system:String x:Key="GeneralSettingsTitle">常规设置</system:String>
 
+    <system:String x:Key="Greek">希腊语</system:String>
+
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/6/20-->
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/6/20-->
-    <system:String x:Key="ModSettingNoCompatibleOptionFoundTheFollowingModsRestrictIt">模组 {0}, 设置 {1} - 找不到兼容选项。以下模组都限制了它的配置:\n\n{2}</system:String>
-    <system:String x:Key="ModChangedSettingTo">模组 {0} - 将设置 {1} 更改为 {2}</system:String>
+    <system:String x:Key="ModSettingNoCompatibleOptionFoundTheFollowingModsRestrictIt">模组 {0}, 设置 {1} - 无法找到兼容选项。以下模组限制了它的配置方式:\n\n{2}</system:String>
+    <system:String x:Key="ModChangedSettingTo">模组 {0} - 已将设置 {1} 更改为 {2}</system:String>
 
     <system:String x:Key="OutputsCurrentCatalogXmlToBelow">将当前 catalog.xml 输出到下方文本区域。</system:String>
-    <system:String x:Key="SaveCatalogXmlToFile">将 catalog.xml 保存到文件</system:String>
-    <system:String x:Key="LoadCatalogXmlFileToEdit">加载 catalog.xml 文件进行编辑</system:String>
-    <system:String x:Key="AddModToCatalog">新增模组到目录</system:String>
-    <system:String x:Key="ImportModFromModXmlOrIro">从 mod.xml 或 .iro 导入模组</system:String>
-    <system:String x:Key="CatalogName">目录名称：</system:String>
-    <system:String x:Key="SaveCatalogXml">保存目录 .xml</system:String>
-    <system:String x:Key="SelectCatalogXmlToLoad">选择要加载的 catalog.xml</system:String>
-    <system:String x:Key="SelectModXmlOrIroFileToLoad">选择要加载的 mod.xml 或 .iro 文件</system:String>
+    <system:String x:Key="SaveCatalogXmlToFile">保存 catalog.xml文件</system:String>
+    <system:String x:Key="LoadCatalogXmlFileToEdit">加载一个 catalog.xml文件并进行编辑</system:String>
+    <system:String x:Key="AddModToCatalog">将模组添加到目录</system:String>
+    <system:String x:Key="ImportModFromModXmlOrIro">从 mod.xml 或.iro 导入模组</system:String>
+    <system:String x:Key="CatalogName">目录名称:</system:String>
+    <system:String x:Key="SaveCatalogXml">保存 catalog.xml</system:String>
+    <system:String x:Key="SelectCatalogXmlToLoad">选择要加载 catalog.xml</system:String>
+    <system:String x:Key="SelectModXmlOrIroFileToLoad">选择要加载的 mod.xml 或 .iro文件</system:String>
     <system:String x:Key="SelectImageToUse">选择要使用的图片</system:String>
     <system:String x:Key="SaveModXml">保存 mod.xml</system:String>
     <system:String x:Key="SelectModXmlToLoad">选择要加载的 mod.xml</system:String>
 
-    <system:String x:Key="SaveAsIroTitle">另存为 .iro</system:String>
-    <system:String x:Key="SaveAsIropTitle">另存为 .irop</system:String>
+    <system:String x:Key="SaveAsIroTitle">将.iro 另存为</system:String>
+    <system:String x:Key="SaveAsIropTitle">将.irop 另存为</system:String>
 
-    <system:String x:Key="SelectTheFolderThatContainsAllTheModFiles">选择包含所有要打包到 IRO 存档中的模组文件的文件夹。</system:String>
-    <system:String x:Key="SelectFolderToOutputUnpackedFiles">选择输出解压文件的文件夹。</system:String>
+    <system:String x:Key="SelectTheFolderThatContainsAllTheModFiles">选择一个包含模组文件的文件夹，用于打包成IRO格式。</system:String>
+    <system:String x:Key="SelectFolderToOutputUnpackedFiles">选择一个文件夹，用于存放解包后的文件。</system:String>
 
-    <system:String x:Key="SelectFLevelLgpFile">选择 FLevel.lgp 文件</system:String>
+    <system:String x:Key="SelectFLevelLgpFile">选择 FLevel.lgp文件</system:String>
 
     <system:String x:Key="GameLauncherSettings">游戏启动器设置</system:String>
 
-    <system:String x:Key="ClickToSelectFf7ExeFile">点击选择您的 FF7.exe 或 FF7_en.exe 文件</system:String>
-    <system:String x:Key="ClickToSelectWhereYourMovieFolderIs">点击选择您的过场动画文件夹位置</system:String>
-    <system:String x:Key="ClickToSelectWhereTexturesAreStored">点击选择纹理存储位置</system:String>
-    <system:String x:Key="ClickToSelectWhereYourModLibraryIs">点击选择您存放模组的文件夹位置</system:String>
+    <system:String x:Key="ClickToSelectFf7ExeFile">点击选择你电脑上的 FF7.exe 或 FF7_en.exe 文件</system:String>
+    <system:String x:Key="ClickToSelectWhereYourMovieFolderIs">点击选择你电脑上的过场动画 movies文件夹</system:String>
+    <system:String x:Key="ClickToSelectWhereTexturesAreStored">点击选择你电脑上的外置贴图 Textures文件夹</system:String>
+    <system:String x:Key="ClickToSelectWhereYourModLibraryIs">点击选择你电脑上存放模组的文件夹</system:String>
 
-    <system:String x:Key="FF7ExeLabel">FF7 exe 文件所在路径：</system:String>
-    <system:String x:Key="MoviesLabel">过场动画文件夹路径：</system:String>
-    <system:String x:Key="TexturesLabel">纹理文件夹路径：</system:String>
-    <system:String x:Key="LibraryLabel">存放模组的文件夹路径：</system:String>
+    <system:String x:Key="FF7ExeLabel">FF7 exe 文件所在路径:</system:String>
+    <system:String x:Key="MoviesLabel">过场动画 movies文件夹路径:</system:String>
+    <system:String x:Key="TexturesLabel">外置贴图 Textures文件夹路径:</system:String>
+    <system:String x:Key="LibraryLabel">存放模组的文件夹路径:</system:String>
 
-    <system:String x:Key="AddSubscriptionURL">添加订阅 URL</system:String>
-    <system:String x:Key="RemoveSubscriptionURL">删除订阅 URL</system:String>
-    <system:String x:Key="EditSubscriptionURL">编辑订阅 URL/名称</system:String>
-    <system:String x:Key="MoveSubscriptionUp">上移订阅。右键点击移至顶部。</system:String>
-    <system:String x:Key="MoveSubscriptionDown">下移订阅。右键点击移至底部</system:String>
+    <system:String x:Key="AddSubscriptionURL">添加订阅链接</system:String>
+    <system:String x:Key="RemoveSubscriptionURL">移除订阅链接</system:String>
+    <system:String x:Key="EditSubscriptionURL">编辑订阅链接/名称</system:String>
+    <system:String x:Key="MoveSubscriptionUp">向上移动订阅。右键点击移动到列表最上方。</system:String>
+    <system:String x:Key="MoveSubscriptionDown">向下移动订阅。右键点击移动到列表最下方。</system:String>
 
-    <system:String x:Key="AddFolder">新增文件夹</system:String>
-    <system:String x:Key="RemoveFolder">删除文件夹</system:String>
-    <system:String x:Key="MoveFolderUp">上移文件夹。右键点击移至顶部。</system:String>
-    <system:String x:Key="MoveFolderDown">下移文件夹。右键点击移至底部。</system:String>
-    <system:String x:Key="EnterUrlInIrosFormat">以 iros:// 格式输入 URL</system:String>
+    <system:String x:Key="AddFolder">添加文件夹</system:String>
+    <system:String x:Key="RemoveFolder">移除文件夹</system:String>
+    <system:String x:Key="MoveFolderUp">向上移动文件夹。右键点击移动到列表最上方。</system:String>
+    <system:String x:Key="MoveFolderDown">向下移动文件夹。右键点击移动到列表最下方。</system:String>
+    <system:String x:Key="EnterUrlInIrosFormat">通过 iros:// 格式访问链接</system:String>
 
-    <system:String x:Key="SelectCustomThemeXmlFile">选择自定义主题 .xml 文件</system:String>
-    <system:String x:Key="SaveCustomThemeXmlFile">保存自定义主题 .xml 文件</system:String>
-
+    <system:String x:Key="SelectCustomThemeXmlFile">选择自定义主题的.xml文件</system:String>
+    <system:String x:Key="SaveCustomThemeXmlFile">保存自定义主题的.xml文件</system:String>
+    
     <!--App Hints Strings-->
-    <system:String x:Key="AppHint1">您可以拖放模组来重新排序列表。</system:String>
-    <system:String x:Key="AppHint2">您可以中键点击模组来激活或停用它。</system:String>
-    <system:String x:Key="AppHint3">您可以双击模组打开模组配置窗口。</system:String>
-    <system:String x:Key="AppHint4">您可以双击"浏览目录"中的模组开始下载它。</system:String>
-    <system:String x:Key="AppHint5">您可以点击"自动排序"按钮快速将模组列表按推荐顺序排列。</system:String>
-    <system:String x:Key="AppHint6">模组现在可以自动更新自己，或通知您有新版本。</system:String>
-    <system:String x:Key="AppHint7">模组作者：您可以将图像 base64 编码到 Readme.html 中。</system:String>
-    <system:String x:Key="AppHint8">模组作者：您可以在 mod.xml 中使用 OrderConstraints 指定加载顺序。</system:String>
-    <system:String x:Key="AppHint9">模组作者：7th Heaven 现在支持树形视图样式的模组配置选项。</system:String>
-    <system:String x:Key="AppHint10">模组作者：7th Heaven 现在支持在目录中使用 iros://ExternalURL 在浏览器中打开下载。</system:String>
-    <system:String x:Key="AppHint11">模组作者：启用常规设置/资源管理器中的上下文菜单以从 Windows 启用右键模组选项。</system:String>
-    <system:String x:Key="AppHint12">模组作者：您可以为目录下载压缩 .7z/RAR/zip 的 IRO，7H 会自动解压它。</system:String>
-    <system:String x:Key="AppHint13">模组作者：您可以编程方式更改其他模组的设置以实现兼容性。</system:String>
-    <system:String x:Key="AppHint14">您可以在 Windows 中双击模组文件打开/导入到 7th Heaven。</system:String>
-    <system:String x:Key="AppHint15">您可以在管理配置文件窗口中双击配置文件加载选定的配置文件。</system:String>
-    <system:String x:Key="AppHint16">配置文件详情现在在设置>配置文件中，然后点击眼睛图标。</system:String>
-    <system:String x:Key="AppHint17">7th Heaven 会记住您之前的配置模组设置，即使您停用并重新激活。</system:String>
-    <system:String x:Key="AppHint18">通过在配置模组窗口中点击"重置为模组默认值"来重置模组设置。</system:String>
-    <system:String x:Key="AppHint19">意外删除了在线模组目录订阅？点击常规设置中的"重置为默认值"。</system:String>
-    <system:String x:Key="AppHint20">右键点击"我的模组"标签在 Windows 中打开您存放模组的文件夹。</system:String>
-    <system:String x:Key="AppHint21">右键点击"浏览目录"标签打开您的目录设置。</system:String>
-    <system:String x:Key="AppHint22">右键点击侧边栏中的箭头将模组发送到顶部或底部。</system:String>
-    <system:String x:Key="AppHint23">弄乱了列视图？点击侧边栏中的"重置列"按钮。</system:String>
-    <system:String x:Key="AppHint24">通过在"我的模组"下的类别列中点击箭头修复旧模组的"未知"类别。</system:String>
-    <system:String x:Key="AppHint25">您可以在 https://forums.qhimm.com 上找到许多问题或问题的答案。</system:String>
-    <system:String x:Key="AppHint26">您可以从帮助菜单中找到许多问题或问题的答案。</system:String>
-    <system:String x:Key="AppHint27">通过前往设置>游戏驱动...更改游戏的图形设置。</system:String>
-    <system:String x:Key="AppHint28">从模组信息面板的下拉箭头更改每个模组的更新设置。</system:String>
-    <system:String x:Key="AppHint29">如果您使用的是 Windows 8或更新版本，7th Heaven 会自动挂载/卸载虚拟游戏光盘。</system:String>
-    <system:String x:Key="AppHint30">7th Heaven 不再需要旧的 Game Converter。现在一切都是自动的！</system:String>
-    <system:String x:Key="AppHint31">您不再需要使用 FF7Config.exe。它的功能已内置到设置>游戏启动器中。</system:String>
-    <system:String x:Key="AppHint32">您知道 7th Heaven 1.0 是在2013年发布的吗？2.0是在7年后的2020年发布的。</system:String>
-    <system:String x:Key="AppHint33">您当前的活动配置文件显示在标题栏的括号中。</system:String>
-   <system:String x:Key="AppHint34">如果游戏窗口被裁剪/未居中，请尝试设置中的高 DPI 修复。</system:String>
-    <system:String x:Key="AppHint35">您可以通过点击列标题来排序"浏览目录"列。</system:String>
-    <system:String x:Key="AppHint36">您可以通过拖放列标题来重新排列列。</system:String>
-    <system:String x:Key="AppHint37">您可以通过点击搜索框旁边的下拉箭头来筛选视图。</system:String>
-    <system:String x:Key="AppHint38">在"游戏启动器设置"中快速切换键盘/游戏手柄控制选项。</system:String>
-    <system:String x:Key="AppHint39">您知道吗？7th Heaven 支持命令行参数(开关)。</system:String>
-    <system:String x:Key="AppHint40">有1998年的光盘？从"游戏启动器设置"自动导入您的过场动画。</system:String>
-    <system:String x:Key="AppHint41">通过前往设置>更改颜色主题自定义您的7th Heaven颜色。</system:String>
-    <system:String x:Key="AppHint42">您可以导出并与他人分享您的自定义颜色主题。</system:String>
-    <system:String x:Key="AppHint43">您可以暂停和恢复某些下载。</system:String>
+    <system:String x:Key="AppHint1">你可以长按左键拖放模组，手动排列模组顺序。</system:String>
+    <system:String x:Key="AppHint2">你可以在任意已安装模组的标题上，单击鼠标中键，快速开启或禁用它。</system:String>
+    <system:String x:Key="AppHint3">你可以左键双击任意模组，快速打开自定义配置。</system:String>
+    <system:String x:Key="AppHint4">你可以左键双击“在线模组目录”界面的任意模组，快速下载使用它。</system:String>
+    <system:String x:Key="AppHint5">你可以点击右侧工具栏中的“自动排序”按钮，可以按照模组名称和及兼容规则，自动排列所有已安装的模组。</system:String>
+    <system:String x:Key="AppHint6">模组现在可以自动更新，或提醒你有新版本。</system:String>
+    <system:String x:Key="AppHint7">对于模组作者: 你可以将图片以base64编码的形式嵌入到你的Readme.html中。</system:String>
+    <system:String x:Key="AppHint8">对于模组作者: 你可以在 mod.xml 中使用“OrderConstraints”命令，自定义模组加载顺序。</system:String>
+    <system:String x:Key="AppHint9">对于模组作者: 第七天堂现在支持树状图样式，方便修改模组配置。</system:String>
+    <system:String x:Key="AppHint10">对于模组作者: 第七天堂现在支持使用 iros://ExternalURL 外部链接格式，以便在浏览器中打开下载链接。</system:String>
+    <system:String x:Key="AppHint11">对于模组作者: 在“常规设置”中开启右键菜单选项，可以在Windows资源管理器中右键点击.iro文件进行操作。</system:String>
+    <system:String x:Key="AppHint12">对于模组作者: 你可以将上传到在线模组目录中的.iro文件，打包成.7z/RAR/zip，第七天堂下载它们时会自动解压缩。</system:String>
+    <system:String x:Key="AppHint13">对于模组作者: 你可以通过编程的方式修改其它模组的配置，以确保它们兼容你的模组。</system:String>
+    <system:String x:Key="AppHint14">如果你将.iro文件的打开方式设置为7th Heaven.exe，则可以在文件夹中双击.iro，将模组快速导入第七天堂。</system:String>
+    <system:String x:Key="AppHint15">在“管理预设文件”界面，你可以左键双击一个预设文件，快速加载它。</system:String>
+    <system:String x:Key="AppHint16">打开“设置 → 预设”，选择一个预设文件，再点击上方眼睛图标，可以通过txt的方式查看预设参数。</system:String>
+    <system:String x:Key="AppHint17">第七天堂会记住你的模组自定义配置。当前模组禁用后再开启，不会丢失自定义配置。</system:String>
+    <system:String x:Key="AppHint18">点击“还原到初始状态”，可以恢复当前模组的默认配置。</system:String>
+    <system:String x:Key="AppHint19">不小心删除了订阅的在线模组目录链接？在“常规设置”里点击“还原默认”进行恢复。</system:String>
+    <system:String x:Key="AppHint20">右键点击“我的模组”选项，可以打开你存放模组的文件夹。</system:String>
+    <system:String x:Key="AppHint21">右键点击“在线模组目录”选项，可以打开在线模组订阅设置界面。</system:String>
+    <system:String x:Key="AppHint22">选中一个模组，右键点击右侧工具栏中的上/下箭头，可以将它移动到列表最上方/最下方。</system:String>
+    <system:String x:Key="AppHint23">模组排列顺序乱了？点击右侧工具栏中的“重置排序”按钮，自动排列所有已安装的模组。</system:String>
+    <system:String x:Key="AppHint24">在“我的模组”界面点击“类型”列中的▼，可以给未知类型“Unknown”的模组手动指定模组类型。</system:String>
+    <system:String x:Key="AppHint25">你可以前往Qhimm论坛 https://forums.qhimm.com 寻找疑难问题的解答。</system:String>
+    <system:String x:Key="AppHint26">你可以在“帮助”菜单里找到很多问题的解决方案。</system:String>
+    <system:String x:Key="AppHint27">打开“设置 → 游戏驱动”，可以修改游戏画面设置。</system:String>
+    <system:String x:Key="AppHint28">在左侧“模组信息”界面的“版本”中，点击▼可以选择模组更新需求（自动升级、提醒或忽略）。</system:String>
+    <system:String x:Key="AppHint29">第七天堂会自动挂载和卸载虚拟光驱。</system:String>
+    <system:String x:Key="AppHint30">第七天堂不再需要旧的游戏转换器。现已实现全面自动化！</system:String>
+    <system:String x:Key="AppHint31">你不需要再使用FF7Config.exe。它的功能已经内置在“设置 → 游戏启动器”中。</system:String>
+    <system:String x:Key="AppHint32">你知道吗？第七天堂1.0版本发布于2013年。而2.0发布于7年后的2020年。</system:String>
+    <system:String x:Key="AppHint33">当前加载的预设文件名称会显示在标题栏的方括号中。</system:String>
+    <system:String x:Key="AppHint34">游戏驱动现已内置高DPI支持。</system:String>
+    <system:String x:Key="AppHint35">你可以点击在线模组界面的“名称/类型/更新日期”等属性，对在线模组列表进行排列。</system:String>
+    <system:String x:Key="AppHint36">你可以直接长按鼠标左键，上下拖动模组名称，调整已安装模组的排列顺序。</system:String>
+    <system:String x:Key="AppHint37">您可以通过点击搜索框旁边的▼来筛选想要查看的模组类型。</system:String>
+    <system:String x:Key="AppHint38">打开“设置 → 键盘/手柄设置”，可以快速切换键盘/手柄预设。</system:String>
+    <system:String x:Key="AppHint39">你知道吗？第七天堂支持命令行参数（switches）。</system:String>
+    <system:String x:Key="AppHint40">如果你拥有1998版游戏光盘，则可以通过“过场动画导入工具”自动导入movies文件夹。</system:String>
+    <system:String x:Key="AppHint41">打开“设置 → 界面配色主题”，自定义你的第七天堂界面颜色与背景图。</system:String>
+    <system:String x:Key="AppHint42">你可以导出自定义界面主题并分享给其他人。</system:String>
+    <system:String x:Key="AppHint43">你可以暂停和恢复部分下载。</system:String>
 
-    <system:String x:Key="ModManagerForFinalFantasy7">最终幻想 VII 模组管理器 ( 由 Tsunamods Team 维护)</system:String>
+    <system:String x:Key="ModManagerForFinalFantasy7">最终幻想VII 模组管理器 ( 由 Tsunamods Team 维护 | 天幻汉化组 汉化)</system:String>
 
 
-    <system:String x:Key="ReleaseDateLabel">发布日期：</system:String>
-    <system:String x:Key="ImageLinkLabel">图片链接：</system:String>
-    <system:String x:Key="InfoLinkLabel">信息链接：</system:String>
-    <system:String x:Key="DownloadLinksHeader" xml:space="preserve">下载链接</system:String>
-    <system:String x:Key="AddLink">新增链接</system:String>
+    <system:String x:Key="ReleaseDateLabel">发布日期:</system:String>
+    <system:String x:Key="ImageLinkLabel">图片链接:</system:String>
+    <system:String x:Key="InfoLinkLabel">信息链接:</system:String>
+    <system:String x:Key="DownloadLinksHeader" xml:space="preserve"> 下载链接 </system:String>
+    <system:String x:Key="AddLink">添加链接</system:String>
 
-    <system:String x:Key="MegaFolderID">Mega 文件夹编号：</system:String>
+    <system:String x:Key="MegaFolderID">Mega网盘ID:</system:String>
 
-    <system:String x:Key="Miscellaneous">杂项</system:String>
-    <system:String x:Key="Animations">动画</system:String>
+    <system:String x:Key="Miscellaneous">模组设置及更新</system:String>
+    <system:String x:Key="Animations">动态资源</system:String>
     <system:String x:Key="BattleModels">战斗模型</system:String>
-    <system:String x:Key="BattleTextures">战斗纹理</system:String>
+    <system:String x:Key="BattleTextures">战斗贴图</system:String>
     <system:String x:Key="FieldModels">场景模型</system:String>
-    <system:String x:Key="FieldTextures">场景纹理</system:String>
+    <system:String x:Key="FieldTextures">场景贴图</system:String>
     <system:String x:Key="Gameplay">游戏玩法</system:String>
     <system:String x:Key="Media">音视频</system:String>
     <system:String x:Key="Minigames">小游戏</system:String>
-    <system:String x:Key="SpellTextures">魔法纹理</system:String>
+    <system:String x:Key="SpellTextures">魔法贴图</system:String>
     <system:String x:Key="UserInterface">游戏界面</system:String>
     <system:String x:Key="WorldModels">大地图模型</system:String>
-    <system:String x:Key="WorldTextures">大地图纹理</system:String>
-    <system:String x:Key="ReShadeShaders">ReShade 着色器</system:String>
+    <system:String x:Key="WorldTextures">大地图贴图</system:String>
+    <system:String x:Key="ReShadeShaders">ReShade着色器</system:String>
+
 
     <system:String x:Key="Cancelling">正在取消</system:String>
 
     <system:String x:Key="Volume">音量</system:String>
 
-    <system:String x:Key="BrazilianPortuguese">Português Brasileiro</system:String>
-    <system:String x:Key="Italian">Italiano</system:String>
+    <system:String x:Key="BrazilianPortuguese">巴西葡萄牙语</system:String>
 
-    <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
+    
+    <!--DEV NOTE: STRINGS BELOW ADDED 4/29/20-->
+    <system:String x:Key="Italian">意大利语</system:String>
 
     <system:String x:Key="SetInGameControls">设置游戏内的按键映射</system:String>
     <system:String x:Key="Keyboard">键盘</system:String>
     <system:String x:Key="Controller">手柄</system:String>
-    <system:String x:Key="ConfirmLabel">[确认]</system:String>
-    <system:String x:Key="CancelLabel">[取消]</system:String>
-    <system:String x:Key="MenuLabel">[菜单]</system:String>
-    <system:String x:Key="SwitchLabel">[切换]</system:String>
-    <system:String x:Key="ScrollUpLabel">[上页]</system:String>
-    <system:String x:Key="ScrollDownLabel">[下页]</system:String>
+    <system:String x:Key="ConfirmLabel">[确定 - CONFIRM]</system:String>
+    <system:String x:Key="CancelLabel">[取消 - CANCEL]</system:String>
+    <system:String x:Key="MenuLabel">[菜单 - MENU]</system:String>
+    <system:String x:Key="SwitchLabel">[切换 - SWITCH]</system:String>
+    <system:String x:Key="ScrollUpLabel">[上页 - SCROLL UP]</system:String>
+    <system:String x:Key="ScrollDownLabel">[下页 - SCROLL DOWN]</system:String>
 
-    <system:String x:Key="CameraLabel">[视角]</system:String>
-    <system:String x:Key="TargetLabel">[目标]</system:String>
-    <system:String x:Key="AssistLabel">[帮助]</system:String>
-    <system:String x:Key="StartLabel">[开始]</system:String>
+    <system:String x:Key="CameraLabel">[视角 - CAMERA]</system:String>
+    <system:String x:Key="TargetLabel">[目标 - TARGET]</system:String>
+    <system:String x:Key="AssistLabel">[帮助 - ASSIST]</system:String>
+    <system:String x:Key="StartLabel">[开始 - START]</system:String>
 
-    <system:String x:Key="UpLabel">[上]</system:String>
-    <system:String x:Key="DownLabel">[下]</system:String>
-    <system:String x:Key="LeftLabel">[左]</system:String>
-    <system:String x:Key="RightLabel">[右]</system:String>
+    <system:String x:Key="UpLabel">[上 - UP]</system:String>
+    <system:String x:Key="DownLabel">[下 - DOWN]</system:String>
+    <system:String x:Key="LeftLabel">[左 - LEFT]</system:String>
+    <system:String x:Key="RightLabel">[右 - RIGHT]</system:String>
 
-    <system:String x:Key="Presets">预设：</system:String>
-    <system:String x:Key="EnablePS4ControllerSupport">启用 PS4 手柄支持</system:String>
-    <system:String x:Key="PS4ControllerSupportTooltip">允许在游戏中使用 PS4 手柄(必须安装 SCP 驱动)</system:String>
-    <system:String x:Key="SaveChangesTooltip">保存控制更改。</system:String>
+    <system:String x:Key="Presets">按键预设:</system:String>
+    <system:String x:Key="EnablePS4ControllerSupport">启用PS4 XInput驱动</system:String>
+    <system:String x:Key="PS4ControllerSupportTooltip">允许使用PS4手柄作为XInput设备，并通过触摸板控制鼠标 (需要安装SCP驱动)</system:String>
+    <system:String x:Key="SaveChangesTooltip">保存控制器设置</system:String>
 
     <system:String x:Key="OpenGameControllersWindow">打开游戏控制器窗口</system:String>
 
-    <system:String x:Key="ControlsTooltip">设置您的游戏内键盘和游戏手柄控制。点击保存图标将上述控制映射保存为自定义配置。</system:String>
+    <system:String x:Key="ControlsTooltip">选择一个预设，然后点击“关闭”即可。</system:String>
 
 
-    <system:String x:Key="StartingPS4ControllerService">正在启动 PS4 手柄服务...</system:String>
-    <system:String x:Key="ServiceAlreadyRunning">服务已在运行...</system:String>
+    <system:String x:Key="StartingPS4ControllerService">启动PS4手柄服务 ...</system:String>
+    <system:String x:Key="ServiceAlreadyRunning">服务已运行 ...</system:String>
 
-    <system:String x:Key="RetryInstallTooltip">重试安装模组</system:String>
+    <system:String x:Key="RetryInstallTooltip">重新尝试安装模组</system:String>
 
 
-    <system:String x:Key="MovieImporter">过场动画导入器...</system:String>
-    <system:String x:Key="AllMovieFilesAlreadyImported" xml:space="preserve">所有过场动画已导入！</system:String>
+    <system:String x:Key="MovieImporter">过场动画导入工具...</system:String>
+    <system:String x:Key="AllMovieFilesAlreadyImported" xml:space="preserve">所有过场动画都已经导入！</system:String>
 
-    <system:String x:Key="ImportMoviesFromDisc">从光盘导入过场动画</system:String>
+    <system:String x:Key="ImportMoviesFromDisc">从光盘导入 movies文件夹里的过场动画</system:String>
 
-    <system:String x:Key="EnableTriggerDpadSupport">启用 DPad 和触发器支持</system:String>
-    <system:String x:Key="TriggerDpadSupportTooltip">在游戏中启用 DPad 和触发器支持。(如果使用第三方映射工具请禁用)</system:String>
+    <system:String x:Key="EnableTriggerDpadSupport">模拟DInput设备的方向键</system:String>
+    <system:String x:Key="TriggerDpadSupportTooltip">使用键盘来模拟游戏内的方向键 (如果你使用 XInput 手柄，则不要选择此项)</system:String>
 
-    <system:String x:Key="MountDiscWithPowershell">使用 PowerShell 挂载光盘</system:String>
-    <system:String x:Key="MountDiscWithWinCDEmu">使用 WinCDEmu 挂载光盘</system:String>
+    <system:String x:Key="MountDiscWithPowershell">通过 PowerShell 加载</system:String>
+    <system:String x:Key="MountDiscWithWinCDEmu">通过 WinCDEmu 加载</system:String>
+    <system:String x:Key="DoNotMount">不加载虚拟光驱</system:String>
 
-    <system:String x:Key="LoadingDevices">正在加载设备...</system:String>
+    <system:String x:Key="LoadingDevices">加载设备 ...</system:String>
 
-    <system:String x:Key="MountOptionToolTip">选择如何挂载虚拟 FF7DISC1 游戏光盘。Windows 7只能使用"使用 WinCDEmu 挂载光盘"选项。</system:String>
+    <system:String x:Key="MountOptionToolTip">选择加载虚拟光驱（FF7DISC1）的方式。Windows 7 系统只能使用 '通过 WinCDEmu 加载' 的选项。</system:String>
 
-    <system:String x:Key="ControlsMenuItemText">控制...</system:String>
+    <system:String x:Key="ControlsMenuItemText">键盘/手柄设置...</system:String>
+    
+    <system:String x:Key="SaveControlsPreset">你需要将当前的结果保存为新的配置文件，请为配置文件起一个名字（中文/英文都可以）:</system:String>
 
-    <system:String x:Key="CheckForSystemDEPStatus">正在检查系统 DEP 状态...</system:String>
+    <!--DEV NOTE: STRINGS BELOW ADDED 7/11/20-->
+    <system:String x:Key="VerifyingEnglishGameFilesExist">正在验证英语版游戏文件是否存在 ...</system:String>
+    <system:String x:Key="FoundLanguageInstalledCreatingEnglishGameFiles">找到安装的语言: {0} 正在创建英语版游戏文件...</system:String>
+    <system:String x:Key="ErrorOnlyEnglishLanguageSupported">错误：仅支持英语原版游戏本体。请确保你的游戏本体是FF7 Steam英文原版或1998英语原版。</system:String>
+    <system:String x:Key="ExtractingLGPFiles">正在提取.lgp文件 ...</system:String>
+    <system:String x:Key="RenamingLanguageSpecificFiles">重命名特定语言的文件 ...</system:String>
+    <system:String x:Key="CouldNotFindFileToRename">无法找到要重命名的文件: {0} ...</system:String>
+    <system:String x:Key="EncodingNewLGPFiles">正在为新的.lgp文件进行编码 ...</system:String>
+    <system:String x:Key="DeletingTemporaryFiles">删除临时文件 ...</system:String>
+    <system:String x:Key="BeginningToPollForGamePadInput">开始加载游戏手柄映射设置 ...</system:String>
+    <system:String x:Key="WaitingForFF7WindowToBeVisible">等待FF7窗口显示出来 (最多等待{0}秒) ...</system:String>
+    <system:String x:Key="CouldNotFindFileToCopy">无法找到要复制的文件: {0} ...</system:String>
+    <system:String x:Key="AnErrorOccurredStartingULGP">启动 ulgp.exe 时出现错误</system:String>
+    <system:String x:Key="UpdatingPathsInSysSettings">使用新的安装路径更新“Sys.Settings”中的路径设置</system:String>
+    <system:String x:Key="ForceMinimizingProgram">强制最小化程序 ...</system:String>
+    <system:String x:Key="FailedToStartAdditionalProgram">无法启动附加程序: {0}</system:String>
+
+    <system:String x:Key="CanaryWarningTitle">使用必读！</system:String>
+    <system:String x:Key="CanaryWarningMessage">感谢您选择使用“开发版”。\n\n这个版本适用于有一定动手能力的玩家，方便支持开发和反馈bug。如果你希望拥有稳定的游戏体验，请勿使用开发版。</system:String>
+
+    <system:String x:Key="PleaseUpdateFFNx">无法加载游戏根目录下的 FFNx.toml文件。你的FFNx版本可能已经过时。请尝试将FFNx升级到最新版本。</system:String>
+
+    <system:String x:Key="CheckForSystemDEPStatus">检查系统 DEP状态...</system:String>
     <system:String x:Key="DEPDetected">检测到 DEP</system:String>
-    <system:String x:Key="DoYouWantToDisableDEP">DEP 当前设置为服务器环境，或根本没有启用。您想将其更改为桌面模式吗？</system:String>
-    <system:String x:Key="SystemDEPDisabledPleaseReboot">DEP 模式成功更新。请重新启动 PC 以使更改生效。</system:String>
-    <system:String x:Key="CannotContinueWithDEPEnabled">DEP 模式不正确。请按照此处描述的步骤调整它以继续：https://7thheaven.rocks/help/dep.html</system:String>
-    <system:String x:Key="SomethingWentWrongWhileDisablingDEP">尝试调整 DEP 时出现问题。您仍然可以手动操作。请按照此处描述的步骤: https://7thheaven.rocks/help/dep.html</system:String>
+    <system:String x:Key="DoYouWantToDisableDEP">你需要为自己的电脑设置“仅为基本的 Windows 程序和服务启用 DEP”，点击“是”自动调整。</system:String>
+    <system:String x:Key="SystemDEPDisabledPleaseReboot">DEP模式调整成功，请重启电脑。</system:String>
+    <system:String x:Key="CannotContinueWithDEPEnabled">DEP模式不正确，请参照这里的方法手动调整: https://7thheaven.rocks/help/dep.html</system:String>
+    <system:String x:Key="SomethingWentWrongWhileDisablingDEP">DEP模式调整失败，请参照这里的方法手动调整: https://7thheaven.rocks/help/dep.html</system:String>
 
-    <system:String x:Key="App4GBPatchRequired">确保游戏 exe 已应用4GB补丁...</system:String>
+    <system:String x:Key="App4GBPatchRequired">确保游戏 exe 应用了4GB补丁..</system:String>
     <system:String x:Key="App4GBPatchApplied">4GB补丁应用成功。</system:String>
 
     <system:String x:Key="OpenSaveGamePath">打开游戏存档文件夹...</system:String>


### PR DESCRIPTION
Compared to the original English StringResources.xaml in 7H, I found that the previous version of StringResources.zh.xaml was missing about 40 lines of text. xujibbs once submitted a version that removed some content, such as String x:Key="DonationLinkLabel". I don’t know why he deleted those parts.

Therefore, I have completely retranslated the Chinese version based on the original StringResources.xaml. It can now be confirmed that the Chinese translation is fully synchronized with 7H English version, with no content omitted.

The currently submitted StringResources.zh.xaml and 7H_GameDriver_UI.zh.xml files have completely replaced xujibbs' versions. Now, FF7 Chinese community players can directly update 7th Heaven through official channels, and its translations are also fully synchronized with the FFSky HD Chinese project.