### PR TITLE
Add Korean language support

### DIFF
--- a/AppCore/StringKey.cs
+++ b/AppCore/StringKey.cs
@@ -658,6 +658,7 @@
         App4GBPatchRequired,
         App4GBPatchApplied,
         SimplifiedChinese,
+        Korean,
         ModShaders
     }
 }

--- a/AppUI/App.xaml.cs
+++ b/AppUI/App.xaml.cs
@@ -417,6 +417,9 @@ namespace AppUI
                     case "zh":
                         dict.Source = new Uri("Resources\\Languages\\StringResources.zh.xaml", UriKind.Relative);
                         break;
+                    case "ko":
+                        dict.Source = new Uri("Resources\\Languages\\StringResources.ko.xaml", UriKind.Relative);
+                        break;
                     default:
                         dict.Source = new Uri("Resources\\StringResources.xaml", UriKind.Relative);
                         cultureCode = "en";

--- a/AppUI/Resources/Languages/7H_GameDriver_UI.ko.xml
+++ b/AppUI/Resources/Languages/7H_GameDriver_UI.ko.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ConfigSpec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <!-- GRAPHICS TAB -->
+  <Setting xsi:type="DropDown">
+    <Group>그래픽</Group>
+    <Name>그래픽 API</Name>
+    <Description>렌더링 소프트웨어를 설정합니다. 자동은 GPU에 따라 최적의 선택을 결정합니다. AMD 카드에서 OpenGL을 사용하면 크래시가 발생할 수 있습니다.</Description>
+    <DefaultValue>renderer_backend = 0</DefaultValue>
+    <Option>
+      <Text>자동</Text>
+      <Settings>renderer_backend = 0</Settings>
+    </Option>
+    <Option>
+      <Text>OpenGL</Text>
+      <Settings>renderer_backend = 1</Settings>
+    </Option>
+    <Option>
+      <Text>DirectX 11</Text>
+      <Settings>renderer_backend = 3</Settings>
+    </Option>
+    <Option>
+      <Text>DirectX 12</Text>
+      <Settings>renderer_backend = 4</Settings>
+    </Option>
+    <Option>
+      <Text>Vulkan</Text>
+      <Settings>renderer_backend = 5</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>그래픽</Group>
+    <Name>디스플레이</Name>
+    <Description>게임을 실행할 기본 디스플레이를 설정합니다.</Description>
+    <DefaultValue>display_index = -1</DefaultValue>
+    <Option>
+      <Text>기본 디스플레이</Text>
+      <Settings>display_index = -1</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>그래픽</Group>
+    <Name>해상도</Name>
+    <Description>게임의 창 크기를 설정합니다. 자동은 창 모드에서는 게임 해상도를, 전체 화면 모드에서는 현재 데스크톱 해상도를 사용합니다.</Description>
+    <DefaultValue>window_size_x = 1280,window_size_y = 720</DefaultValue>
+    <Option>
+      <Text>자동</Text>
+      <Settings>window_size_x = 0,window_size_y = 0</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>그래픽</Group>
+    <Name>창 모드</Name>
+    <Description>게임을 일반 창 모드 또는 테두리 없는 전체 화면으로 표시합니다.</Description>
+    <DefaultValue>fullscreen = false,borderless = false</DefaultValue>
+    <Option>
+      <Text>창 모드</Text>
+      <Settings>fullscreen = false,borderless = false</Settings>
+    </Option>
+    <Option>
+      <Text>전체 화면</Text>
+      <Settings>fullscreen = true,borderless = false</Settings>
+    </Option>
+    <Option>
+      <Text>테두리 없음</Text>
+      <Settings>fullscreen = false,borderless = true</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>그래픽</Group>
+    <Name>화면 비율</Name>
+    <Description>4:3 화면 비율을 유지하기 위해 필요에 따라 검은색 테두리를 추가합니다.</Description>
+    <DefaultValue>aspect_ratio = 0</DefaultValue>
+    <Option>
+      <Text>원본 (4:3)</Text>
+      <Settings>aspect_ratio = 0</Settings>
+    </Option>
+    <Option>
+      <Text>화면에 맞게 늘리기</Text>
+      <Settings>aspect_ratio = 1</Settings>
+    </Option>
+    <Option>
+      <Text>와이드스크린 (16:9)</Text>
+      <Settings>aspect_ratio = 2</Settings>
+    </Option>
+    <Option>
+      <Text>와이드스크린 (16:10)</Text>
+      <Settings>aspect_ratio = 3</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>그래픽</Group>
+    <Name>안티앨리어싱</Name>
+    <Description>2x 또는 4x MSAA 필터링을 적용합니다. 계단 현상을 줄이고 이미지 품질을 향상시킵니다. 성능에 심각한 영향을 줄 수 있습니다.</Description>
+    <DefaultValue>enable_antialiasing = 0</DefaultValue>
+    <Option>
+      <Text>끄기</Text>
+      <Settings>enable_antialiasing = 0</Settings>
+    </Option>
+    <Option>
+      <Text>2x MSAA</Text>
+      <Settings>enable_antialiasing = 2</Settings>
+    </Option>
+    <Option>
+      <Text>4x MSAA</Text>
+      <Settings>enable_antialiasing = 4</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>그래픽</Group>
+	<Name>수직 언크롭</Name>
+	<Description>이미지 언크롭을 적용하여 화면 상단과 하단의 검은색 막대를 제거합니다</Description>
+    <DefaultValue>enable_uncrop = true</DefaultValue>
+    <TrueSetting>enable_uncrop = true</TrueSetting>
+    <FalseSetting>enable_uncrop = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>그래픽</Group>
+    <Name>이방성 필터링</Name>
+    <Description>고해상도 텍스처에 필터를 적용하여 더 선명한 이미지를 만듭니다. 메모리 사용량 증가로 인해 성능에 영향을 줄 수 있습니다</Description>
+    <DefaultValue>enable_anisotropic = true</DefaultValue>
+    <TrueSetting>enable_anisotropic = true</TrueSetting>
+    <FalseSetting>enable_anisotropic = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>그래픽</Group>
+    <Name>수직 동기화</Name>
+    <Description>게임의 프레임 속도를 모니터 주사율과 동기화합니다. 성능에 부정적인 영향을 주거나 60fps 모드를 방해할 수 있습니다. 화면 찢김 현상이 발생하면 켜세요. *속도 핵 제한!*</Description>
+    <DefaultValue>enable_vsync = false</DefaultValue>
+    <TrueSetting>enable_vsync = true</TrueSetting>
+    <FalseSetting>enable_vsync = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>그래픽</Group>
+    <Name>고급 조명</Name>
+    <Description>실시간 조명 지원을 활성화합니다. 참고: 이 기능은 최신 CPU가 필요합니다. 속도 저하가 발생하면 이 옵션을 비활성화하세요.</Description>
+    <DefaultValue>enable_lighting = false</DefaultValue>
+    <TrueSetting>enable_lighting = true</TrueSetting>
+    <FalseSetting>enable_lighting = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>그래픽</Group>
+    <Name>NTSC-J 색역 모드</Name>
+    <Description>FF7이 원래 설계된 1990년대 일본 텔레비전 세트의 색역을 시뮬레이션합니다.</Description>
+    <DefaultValue>enable_ntscj_gamut_mode = false</DefaultValue>
+    <TrueSetting>enable_ntscj_gamut_mode = true</TrueSetting>
+    <FalseSetting>enable_ntscj_gamut_mode = false</FalseSetting>
+  </Setting>
+
+  <!-- CHEATS TAB -->
+  <Setting xsi:type="DropDown">
+    <Group>치트</Group>
+    <Name>랜덤 전투</Name>
+    <Description>설정 불가. 게임 중 랜덤 전투 인카운터를 켜고 끕니다.{0}사용법: 'CTRL+B' 또는 'L3, 그런 다음 Circle'</Description>
+    <DefaultValue></DefaultValue>
+    <Option>
+      <Text>설명 참조</Text>
+      <Settings></Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>치트</Group>
+    <Name>자동 공격</Name>
+    <Description>설정 불가. 게임 중 자동 공격을 켜고 끕니다.{0}사용법: 'CTRL+A' 또는 'L3, 그런 다음 Triangle'</Description>
+    <DefaultValue></DefaultValue>
+    <Option>
+      <Text>설명 참조</Text>
+      <Settings></Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>치트</Group>
+    <Name>동영상 건너뛰기</Name>
+    <Description>설정 불가. 즉시 동영상 끝으로 건너뜁니다.{0}사용법: 'CTRL+S' 또는 'L3, 그런 다음 Square'</Description>
+    <DefaultValue></DefaultValue>
+    <Option>
+      <Text>설명 참조</Text>
+      <Settings></Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>치트</Group>
+    <Name>소프트 리셋</Name>
+    <Description>설정 불가. 게임 오버로 게임을 빠르게 리셋합니다. *전투 중 리셋하지 마세요.*{0}사용법: 'CTRL+R' 또는 'L3, 그런 다음 Select+Start'</Description>
+    <DefaultValue></DefaultValue>
+    <Option>
+      <Text>설명 참조</Text>
+      <Settings></Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>치트</Group>
+    <Name>속도 핵 단계</Name>
+    <Description>각 트리거마다 속도를 높이거나 낮추는 양입니다.{0}사용법: 속도 변경은 'CTRL+위/아래' 또는 'L3, 그런 다음 L1/R1', 켜기/끄기는 'CTRL+왼쪽/오른쪽' 또는 'L3, 그런 다음 L2/R2'</Description>
+    <DefaultValue>speedhack_step = 0.5</DefaultValue>
+    <Option>
+      <Text>0.5</Text>
+      <Settings>speedhack_step = 0.5</Settings>
+    </Option>
+    <Option>
+      <Text>1.0</Text>
+      <Settings>speedhack_step = 1.0</Settings>
+    </Option>
+    <Option>
+      <Text>2.0</Text>
+      <Settings>speedhack_step = 2.0</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>치트</Group>
+    <Name>속도 핵 최대값</Name>
+    <Description>정상 속도로 다시 순환하기 전에 설정할 최대 속도입니다.</Description>
+    <DefaultValue>speedhack_max = 8.0</DefaultValue>
+    <Option>
+      <Text>2x</Text>
+      <Settings>speedhack_max = 2.0</Settings>
+    </Option>
+    <Option>
+      <Text>4x</Text>
+      <Settings>speedhack_max = 4.0</Settings>
+    </Option>
+    <Option>
+      <Text>6x</Text>
+      <Settings>speedhack_max = 6.0</Settings>
+    </Option>
+    <Option>
+      <Text>8x</Text>
+      <Settings>speedhack_max = 8.0</Settings>
+    </Option>
+    <Option>
+      <Text>10x</Text>
+      <Settings>speedhack_max = 10.0</Settings>
+    </Option>
+    <Option>
+      <Text>12x</Text>
+      <Settings>speedhack_max = 12.0</Settings>
+    </Option>
+  </Setting>
+
+  <!-- CONTROLS TAB -->
+  <Setting xsi:type="Checkbox">
+    <Group>컨트롤</Group>
+    <Name>아날로그 컨트롤</Name>
+    <Description>완전한 전방향 아날로그 컨트롤 지원을 활성화합니다. 여기에는 전투 자유 카메라 이동과 필드에서의 360도 완전 아날로그 이동이 포함됩니다.</Description>
+    <DefaultValue>enable_analogue_controls = false</DefaultValue>
+    <TrueSetting>enable_analogue_controls = true</TrueSetting>
+    <FalseSetting>enable_analogue_controls = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>컨트롤</Group>
+    <Name>자동 달리기</Name>
+    <Description>자동 달리기 동작을 활성화합니다. 왼쪽 아날로그 스틱이 얼마나 기울어져 있는지에 따라 클라우드가 자동으로 달립니다.</Description>
+    <DefaultValue>enable_auto_run = false</DefaultValue>
+    <TrueSetting>enable_auto_run = true</TrueSetting>
+    <FalseSetting>enable_auto_run = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>컨트롤</Group>
+    <Name>수평 컨트롤 반전</Name>
+    <Description>전투에서 카메라를 조작할 때 카메라 수평 이동을 반전시킵니다.</Description>
+    <DefaultValue>enable_inverted_horizontal_camera_controls = false</DefaultValue>
+    <TrueSetting>enable_inverted_horizontal_camera_controls = true</TrueSetting>
+    <FalseSetting>enable_inverted_horizontal_camera_controls = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>컨트롤</Group>
+    <Name>수직 컨트롤 반전</Name>
+    <Description>전투에서 카메라를 조작할 때 카메라 수직 이동을 반전시킵니다.</Description>
+    <DefaultValue>enable_inverted_vertical_camera_controls = false</DefaultValue>
+    <TrueSetting>enable_inverted_vertical_camera_controls = true</TrueSetting>
+    <FalseSetting>enable_inverted_vertical_camera_controls = false</FalseSetting>
+  </Setting>
+
+  <!-- ADVANCED TAB -->
+  <Setting xsi:type="Checkbox">
+    <Group>고급</Group>
+    <Name>Steam 호환성</Name>
+    <Description>Steam 기능(게임 활동, 컨트롤러, 도전 과제)을 활성화합니다. Steam이 실행 중이어야 합니다.</Description>
+    <DefaultValue>enable_steam_achievements = false</DefaultValue>
+    <TrueSetting>enable_steam_achievements = true</TrueSetting>
+    <FalseSetting>enable_steam_achievements = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>고급</Group>
+    <Name>디버그 정보 표시</Name>
+    <Description>오버레이 또는 제목 표시줄에 렌더링 과정/성능에 대한 실시간 정보를 표시합니다.</Description>
+    <DefaultValue>show_stats = false</DefaultValue>
+    <TrueSetting>show_stats = true</TrueSetting>
+    <FalseSetting>show_stats = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>고급</Group>
+    <Name>드라이버 버전 표시</Name>
+    <Description>오버레이 또는 제목 표시줄에 현재 사용 중인 드라이버 버전을 표시합니다.</Description>
+    <DefaultValue>show_version = false</DefaultValue>
+    <TrueSetting>show_version = true</TrueSetting>
+    <FalseSetting>show_version = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>고급</Group>
+    <Name>FPS 표시</Name>
+    <Description>오버레이 또는 제목 표시줄에 현재 초당 프레임 수를 표시합니다.</Description>
+    <DefaultValue>show_fps = false</DefaultValue>
+    <TrueSetting>show_fps = true</TrueSetting>
+    <FalseSetting>show_fps = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>고급</Group>
+    <Name>그래픽 API 표시</Name>
+    <Description>오버레이 또는 제목 표시줄에 현재 사용 중인 그래픽 API(OpenGL/DirectX11)를 표시합니다.</Description>
+    <DefaultValue>show_renderer_backend = false</DefaultValue>
+    <TrueSetting>show_renderer_backend = true</TrueSetting>
+    <FalseSetting>show_renderer_backend = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>고급</Group>
+    <Name>내부 해상도 스케일러</Name>
+    <Description>640x480 내부 해상도에 다음 배율을 곱합니다. 값이 높을수록 더 강력한 GPU가 필요합니다. 높은 값은 스케일링 아티팩트를 제거할 수 있습니다. *표시된 값은 최적의 성능/품질 비율입니다.</Description>
+    <DefaultValue>internal_resolution_scale = 0</DefaultValue>
+    <Option>
+      <Text>자동</Text>
+      <Settings>internal_resolution_scale = 0</Settings>
+    </Option>
+    <Option>
+      <Text>1x (아티팩트가 발생할 수 있음)</Text>
+      <Settings>internal_resolution_scale = 1</Settings>
+    </Option>
+    <Option>
+      <Text>2x</Text>
+      <Settings>internal_resolution_scale = 2</Settings>
+    </Option>
+    <Option>
+      <Text>*4x</Text>
+      <Settings>internal_resolution_scale = 4</Settings>
+    </Option>
+    <Option>
+      <Text>*6x</Text>
+      <Settings>internal_resolution_scale = 6</Settings>
+    </Option>
+    <Option>
+      <Text>8x</Text>
+      <Settings>internal_resolution_scale = 8</Settings>
+    </Option>
+  </Setting>
+
+</ConfigSpec>

--- a/AppUI/Resources/Languages/StringResources.br.xaml
+++ b/AppUI/Resources/Languages/StringResources.br.xaml
@@ -723,6 +723,7 @@ Clique em 'Cancelar' para parar o processo.</system:String>
     <system:String x:Key="Spanish">Espanhol</system:String>
     <system:String x:Key="Japanese">Japonês</system:String>
     <system:String x:Key="SimplifiedChinese">Chinês Simplificado</system:String>
+    <system:String x:Key="Korean">Coreano</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/Resources/Languages/StringResources.de.xaml
+++ b/AppUI/Resources/Languages/StringResources.de.xaml
@@ -725,6 +725,7 @@ Auf "Abbrechen" klicken, um den Vorgang zu unterbrechen.</system:String>
     <system:String x:Key="Spanish">Spanisch</system:String>
     <system:String x:Key="Japanese">Japanisch</system:String>
     <system:String x:Key="SimplifiedChinese">Vereinfachtes Chinesisch</system:String>
+    <system:String x:Key="Korean">Koreanisch</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/Resources/Languages/StringResources.es.xaml
+++ b/AppUI/Resources/Languages/StringResources.es.xaml
@@ -728,6 +728,7 @@ Haz clic en 'Cancelar' para detener el proceso.</system:String>
     <system:String x:Key="Spanish">Español</system:String>
     <system:String x:Key="Japanese">Japonés</system:String>
     <system:String x:Key="SimplifiedChinese">Chino Simplificado</system:String>
+    <system:String x:Key="Korean">Coreano</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/Resources/Languages/StringResources.fr.xaml
+++ b/AppUI/Resources/Languages/StringResources.fr.xaml
@@ -718,6 +718,7 @@ Cliquer sur 'Annuler' pour arrêter la copie.</system:String>
     <system:String x:Key="Spanish">Espagnol</system:String>
     <system:String x:Key="Japanese">Japonais</system:String>
     <system:String x:Key="SimplifiedChinese">Chinois Simplifié</system:String>
+    <system:String x:Key="Korean">Coréen</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/Resources/Languages/StringResources.gr.xaml
+++ b/AppUI/Resources/Languages/StringResources.gr.xaml
@@ -724,6 +724,7 @@
     <system:String x:Key="Spanish">Ισπανικά</system:String>
     <system:String x:Key="Japanese">Ιαπωνικά</system:String>
     <system:String x:Key="SimplifiedChinese">απλοποιημένα κινέζικα</system:String>
+    <system:String x:Key="Korean">Κορεατικά</system:String>
 
     <!--GameLauncher Strings-->
     <system:String x:Key="CheckingFf7IsNotRunning">Ο έλεγχος δείχνει πως το FF7 δεν εκτελείται ...</system:String>

--- a/AppUI/Resources/Languages/StringResources.it.xaml
+++ b/AppUI/Resources/Languages/StringResources.it.xaml
@@ -722,6 +722,7 @@ Premi 'Annulla' per interrompere il processo.</system:String>
     <system:String x:Key="Spanish">Spagnolo</system:String>
     <system:String x:Key="Japanese">Giapponese</system:String>
     <system:String x:Key="SimplifiedChinese">Cinese Semplificato</system:String>
+    <system:String x:Key="Korean">Coreano</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/Resources/Languages/StringResources.ja.xaml
+++ b/AppUI/Resources/Languages/StringResources.ja.xaml
@@ -715,6 +715,7 @@ Click 'Cancel' to stop the process.</system:String>
     <system:String x:Key="Spanish">Spanish</system:String>
     <system:String x:Key="Japanese">Japanese</system:String>
     <system:String x:Key="SimplifiedChinese">Simplified Chinese</system:String>
+    <system:String x:Key="Korean">韓国語</system:String>
 
     <!--GameLauncher Strings-->
     <system:String x:Key="CheckingFf7IsNotRunning">Checking FF7 is not running ...</system:String>

--- a/AppUI/Resources/Languages/StringResources.ko.xaml
+++ b/AppUI/Resources/Languages/StringResources.ko.xaml
@@ -1,0 +1,1262 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Main Window Buttons-->
+    <system:String x:Key="Play">플레이</system:String>
+    <system:String x:Key="PlayWithMods">모드와 함께 플레이 (기본)</system:String>
+    <system:String x:Key="PlayWithNoMods">모드 없이 플레이</system:String>
+    <system:String x:Key="PlayWithMinimalValidation">최소 검증으로 플레이</system:String>
+    <system:String x:Key="PlayWithDebugLog">디버그 로그와 함께 플레이</system:String>
+    <system:String x:Key="PlayWithVariableDump">변수 덤프와 함께 플레이</system:String>
+
+    <system:String x:Key="Settings">설정</system:String>
+    <system:String x:Key="ChangeColorTheme">색상 테마 변경...</system:String>
+    <system:String x:Key="GeneralSettings">일반 설정...</system:String>
+    <system:String x:Key="GameDriver">게임 드라이버...</system:String>
+    <system:String x:Key="GameLauncher">게임 런처...</system:String>
+    <system:String x:Key="Profiles">프로필...</system:String>
+    <system:String x:Key="Language">언어...</system:String>
+
+
+    <system:String x:Key="Tools">도구</system:String>
+    <system:String x:Key="CatalogModCreationTool">카탈로그/모드 생성 도구...</system:String>
+    <system:String x:Key="ChunkTool">청크 도구...</system:String>
+    <system:String x:Key="IROTools">IRO 도구...</system:String>
+
+    <system:String x:Key="Help">도움말</system:String>
+    <system:String x:Key="HelpOpen">도움말 열기</system:String>
+    <system:String x:Key="HelpOpenAbout">정보</system:String>
+
+    <system:String x:Key="MyMods">내 모드</system:String>
+    <system:String x:Key="MyModsTooltip">내 모드 탭을 우클릭하여 모드 라이브러리 폴더를 열 수 있습니다</system:String>
+
+    <system:String x:Key="BrowseCatalog">카탈로그 탐색</system:String>
+    <system:String x:Key="BrowseCatalogTooltip">카탈로그 탐색 탭을 우클릭하여 카탈로그 설정을 열 수 있습니다</system:String>
+
+    <system:String x:Key="SearchHint">여기에 검색어를 입력하세요 ...</system:String>
+    <system:String x:Key="FiltersTooltip">클릭하여 필터링할 카테고리와 태그를 선택하세요.</system:String>
+
+    <system:String x:Key="StatusBarTooltip">클릭하여 앱 로그를 확인하세요</system:String>
+
+
+    <!--Mod Info Panel-->
+    <system:String x:Key="ModInfoHeader" xml:space="preserve"> 모드 정보 </system:String>
+    <system:String x:Key="NameLabel">이름:</system:String>
+    <system:String x:Key="AuthorLabel">제작자:</system:String>
+    <system:String x:Key="ReleasedLabel">출시일:</system:String>
+    <system:String x:Key="CategoryLabel">카테고리:</system:String>
+    <system:String x:Key="VersionLabel">버전:</system:String>
+
+    <system:String x:Key="ClickHere">여기를 클릭하세요</system:String>
+    <system:String x:Key="None">없음</system:String>
+
+    <system:String x:Key="AutoUpdateInstall">자동 업데이트/설치</system:String>
+    <system:String x:Key="Ignore">무시</system:String>
+    <system:String x:Key="Notify">알림</system:String>
+
+    <system:String x:Key="DescriptionLabel">설명:</system:String>
+    <system:String x:Key="LinkLabel">링크:</system:String>
+    <system:String x:Key="ReadmeLabel">리드미:</system:String>
+    <system:String x:Key="ReleaseNotesLabel">릴리즈 노트:</system:String>
+    <system:String x:Key="DonationLinkLabel">후원 링크:</system:String>
+
+    <system:String x:Key="NoPreviewImage">미리보기 이미지 없음</system:String>
+
+
+    <!-- Browse Catalog Tab -->
+    <system:String x:Key="Name">이름</system:String>
+    <system:String x:Key="Author">제작자</system:String>
+    <system:String x:Key="Released">출시일</system:String>
+    <system:String x:Key="Category">카테고리</system:String>
+    <system:String x:Key="Size">크기</system:String>
+    <system:String x:Key="Inst">설치됨</system:String>
+
+
+    <system:String x:Key="RefreshCatalogTooltip">모든 구독을 강제 업데이트하고 카탈로그를 새로고침</system:String>
+    <system:String x:Key="DownloadModTooltip">선택한 모드 다운로드</system:String>
+    <system:String x:Key="ResetColumnsTooltip">열 초기화</system:String>
+
+    <system:String x:Key="Item">항목</system:String>
+    <system:String x:Key="Progress">진행률</system:String>
+    <system:String x:Key="Speed">속도</system:String>
+    <system:String x:Key="TimeLeft">남은 시간</system:String>
+
+    <system:String x:Key="CancelDownloadTooltip">선택한 다운로드 취소</system:String>
+
+
+    <!--My Mods Tab-->
+    <system:String x:Key="Active">활성화됨</system:String>
+
+    <system:String x:Key="ImportModTooltip">모드 가져오기</system:String>
+    <system:String x:Key="MoveUpTooltip">위로 이동/우클릭하여 맨 위로 이동</system:String>
+    <system:String x:Key="MoveDownTooltip">아래로 이동/우클릭하여 맨 아래로 이동</system:String>
+    <system:String x:Key="AutoSortTooltip">카테고리 로드 순서에 따라 모드 자동 정렬</system:String>
+    <system:String x:Key="ConfigureModTooltip">모드 설정</system:String>
+    <system:String x:Key="ActivateAllTooltip">모든 모드 활성화</system:String>
+    <system:String x:Key="DeactivateAllTooltip">모든 모드 비활성화</system:String>
+    <system:String x:Key="RefreshListTooltip">목록 새로고침</system:String>
+    <system:String x:Key="UninstallModTooltip">모드 제거</system:String>
+
+
+    <!--Generic MessageBox Buttons-->
+    <system:String x:Key="OK">확인</system:String>
+    <system:String x:Key="Cancel">취소</system:String>
+    <system:String x:Key="Close">닫기</system:String>
+    <system:String x:Key="Yes">예</system:String>
+    <system:String x:Key="No">아니오</system:String>
+    <system:String x:Key="Off">끄기</system:String>
+    <system:String x:Key="On">켜기</system:String>
+    <system:String x:Key="ResetDefaults">기본값으로 초기화</system:String>
+    <system:String x:Key="Save">저장</system:String>
+    <system:String x:Key="Load">불러오기</system:String>
+    <system:String x:Key="Go">실행</system:String>
+
+
+    <!--Window Titles-->
+    <system:String x:Key="GameLauncherWindowTitle">게임 실행 중</system:String>
+    <system:String x:Key="CatalogCreationWindowTitle">카탈로그 및 모드 생성 도구</system:String>
+    <system:String x:Key="GameDriverWindowTitle">게임 드라이버 설정 구성</system:String>
+    <system:String x:Key="UnexpectedErrorWindowTitle">7th Heaven - 예기치 않은 오류!</system:String>
+    <system:String x:Key="AllowModToRun">모드 실행을 허용하시겠습니까?</system:String>
+    <system:String x:Key="Warning">경고</system:String>
+    <system:String x:Key="Requirements">요구 사항</system:String>
+    <system:String x:Key="ExternalDownload">외부 다운로드?</system:String>
+    <system:String x:Key="MissingPath">경로 누락</system:String>
+    <system:String x:Key="ExtractComplete">압축 해제 완료</system:String>
+    <system:String x:Key="InsertDisc">디스크 삽입</system:String>
+    <system:String x:Key="MissingRequiredInput">필수 입력 누락</system:String>
+    <system:String x:Key="IROToolsWindowTitle">IRO 도구</system:String>
+    <system:String x:Key="ChunkToolWindowTitle">청크 도구</system:String>
+    <system:String x:Key="ManageProfiles">프로필 관리</system:String>
+    <system:String x:Key="SetLanguageWindowTitle">언어 설정</system:String>
+
+
+    <!--Allow Mod To Run Window-->
+    <system:String x:Key="NoDontActivateThisMod">아니오, 이 모드를 활성화하지 않겠습니다</system:String>
+    <system:String x:Key="YesActivateThisMod">예, 이 모드를 활성화하겠습니다</system:String>
+    <system:String x:Key="DontAskAgainForAnyMods">모든 모드에 대해 다시 묻지 않겠습니다</system:String>
+
+    <!--Game Launcher Settings Window-->
+    <system:String x:Key="OptionsHeader" xml:space="preserve"> 옵션 </system:String>
+    <system:String x:Key="AutoMountDisc">게임 디스크 자동 마운트</system:String>
+    <system:String x:Key="AutoMountDiscTooltip">게임 시작 시 게임 디스크 ISO를 자동으로 마운트합니다. Windows 8 이상에서만 지원됩니다. Windows 7 이하에서는 디스크를 직접 삽입하거나 ISO를 수동으로 마운트해야 합니다.</system:String>
+
+    <system:String x:Key="AutoDismountDisc">게임 디스크 자동 마운트 해제</system:String>
+    <system:String x:Key="AutoDismountDiscTooltip">게임 종료 시 게임 디스크 ISO를 자동으로 마운트 해제합니다. Windows 8 이상에서만 지원됩니다. Windows 7 이하에서는 디스크를 직접 꺼내거나 ISO를 수동으로 마운트 해제해야 합니다.</system:String>
+
+    <system:String x:Key="AutoUpdatePath">디스크 경로 자동 업데이트</system:String>
+    <system:String x:Key="AutoUpdatePathTooltip">디스크의 드라이브 문자가 변경된 경우를 감지하여 게임이 새 위치를 자동으로 가리키도록 업데이트합니다.</system:String>
+
+    <system:String x:Key="ShowGameLauncher">게임 런처 표시</system:String>
+    <system:String x:Key="ShowGameLauncherTooltip">FF7 시작 시 게임 런처 창을 표시하여 실행 과정의 자세한 출력을 확인합니다.</system:String>
+
+    <system:String x:Key="ControlsLabel">컨트롤:</system:String>
+
+    <system:String x:Key="SaveControlsTooltip">현재 게임 내 컨트롤 설정을 저장합니다.</system:String>
+    <system:String x:Key="DeleteControlsTooltip">선택한 사용자 정의 컨트롤 설정을 삭제합니다.</system:String>
+
+    <system:String x:Key="CompatibilityHeader" xml:space="preserve"> 호환성 </system:String>
+    <system:String x:Key="HighDpiScalingFix">고DPI 배율 수정</system:String>
+    <system:String x:Key="HighDpiScalingFixTooltip">게임 화면이 잘리거나 중앙에 표시되지 않는 문제를 수정할 수 있습니다. 고DPI 디스플레이에서 사용하세요. 또는 Windows 디스플레이 설정에서 배율을 100%로 변경하세요.</system:String>
+
+    <system:String x:Key="ReunionDriverFix">Reunion 드라이버 수정</system:String>
+    <system:String x:Key="ReunionDriverFixTooltip">게임 실행 시 ddraw.dll을 Reunion.dll.bak으로 임시 이름을 변경한 후 즉시 되돌립니다. 7H 외부에서의 Reunion 플레이에는 영향을 미치지 않습니다.</system:String>
+
+
+    <system:String x:Key="ImportMoviesHeader" xml:space="preserve"> 디스크에서 동영상 가져오기 </system:String>
+    <system:String x:Key="Import">가져오기</system:String>
+    <system:String x:Key="ImportTooltip">디스크에서 누락된 동영상을 가져옵니다.</system:String>
+
+
+    <system:String x:Key="AudioDeviceHeader" xml:space="preserve"> 오디오 출력 장치 </system:String>
+    <system:String x:Key="SoundDeviceLabel">사운드 장치:</system:String>
+    <system:String x:Key="SoundDeviceTooltip">FF7의 오디오 출력 장치를 선택합니다.</system:String>
+
+    <system:String x:Key="TestSoundTooltip">선택한 사운드 장치와 음악/효과음 볼륨을 테스트합니다. 테스트 사운드 제공: Enrico Deiana.</system:String>
+    <system:String x:Key="TestLeftSoundTooltip">선택한 사운드 장치와 음악/효과음 볼륨의 왼쪽 채널을 테스트합니다. 테스트 사운드 제공: Enrico Deiana.</system:String>
+    <system:String x:Key="TestRightSoundTooltip">선택한 사운드 장치와 음악/효과음 볼륨의 오른쪽 채널을 테스트합니다. 테스트 사운드 제공: Enrico Deiana.</system:String>
+
+    <system:String x:Key="MidiDeviceLabel">MIDI 장치:</system:String>
+    <system:String x:Key="MidiDataLabel">MIDI 데이터:</system:String>
+    <system:String x:Key="MidiDeviceTooltip">FF7의 MIDI 출력 장치를 선택합니다.</system:String>
+
+    <system:String x:Key="SFXVolumeLabel">효과음 볼륨:</system:String>
+    <system:String x:Key="SFXVolumeTooltip">게임 내 효과음 볼륨을 설정합니다.</system:String>
+
+    <system:String x:Key="MusicVolumeLabel">음악 볼륨:</system:String>
+    <system:String x:Key="MusicVolumeTooltip">게임 내 음악 볼륨을 설정합니다.</system:String>
+
+    <system:String x:Key="VoiceVolumeLabel">음성 볼륨:</system:String>
+    <system:String x:Key="VoiceVolumeTooltip">게임 내 음성 볼륨을 설정합니다.</system:String>
+
+    <system:String x:Key="AmbientVolumeLabel">환경음 볼륨:</system:String>
+    <system:String x:Key="AmbientVolumeTooltip">게임 내 환경음 볼륨을 설정합니다.</system:String>
+
+    <system:String x:Key="MovieVolumeLabel">동영상 볼륨:</system:String>
+    <system:String x:Key="MovieVolumeTooltip">게임 내 동영상 볼륨을 설정합니다.</system:String>
+
+    <system:String x:Key="LogVolumeControl">디지털 볼륨 제어</system:String>
+    <system:String x:Key="LogVolumeControlTooltip">볼륨이 부드럽게 변하지 않는다고 느껴지면 이 옵션을 해제하세요.</system:String>
+
+    <system:String x:Key="ReverseSpeakers">스피커 좌우 바꾸기</system:String>
+    <system:String x:Key="ReverseSpeakersTooltip">체크 시 왼쪽과 오른쪽 채널을 바꿉니다.</system:String>
+
+
+    <system:String x:Key="GraphicsDriverHeader" xml:space="preserve"> 그래픽 드라이버 옵션 </system:String>
+    <system:String x:Key="RendererLabel">렌더러:</system:String>
+    <system:String x:Key="RendererTooltip">FF7 렌더링에 사용할 그래픽 드라이버를 선택합니다. 모드는 '사용자 정의 7H 게임 드라이버'로 설정된 경우에만 작동합니다</system:String>
+
+    <system:String x:Key="QuarterScreen">쿼터 스크린</system:String>
+    <system:String x:Key="QuarterScreenTooltip">게임을 창 모드(쿼터 스크린)로 실행합니다. '소프트웨어 렌더러' 또는 'Direct3D 하드웨어 가속'으로 설정된 경우에만 적용됩니다.</system:String>
+
+    <system:String x:Key="FullScreen">전체 화면</system:String>
+    <system:String x:Key="FullScreenTooltip">게임을 전체 화면으로 실행합니다. '소프트웨어 렌더러' 또는 'Direct3D 하드웨어 가속'으로 설정된 경우에만 적용됩니다.</system:String>
+
+    <system:String x:Key="HardwareGraphicsTooltip">하드웨어 가속에 사용할 옵션을 설정합니다. 'Direct3D 하드웨어 가속'으로 설정된 경우에만 적용됩니다.</system:String>
+
+
+    <system:String x:Key="ProgramsToRunHeader" xml:space="preserve"> FF7 실행 전에 실행할 프로그램: </system:String>
+    <system:String x:Key="ProgramNameHint">실행할 프로그램의 전체 경로를 입력하세요</system:String>
+    <system:String x:Key="ProgramArgsHint">프로그램 인수를 입력하세요</system:String>
+
+    <system:String x:Key="AddProgramTooltip">FF7 시작 전에 실행할 프로그램을 추가합니다.</system:String>
+    <system:String x:Key="RemoveProgramTooltip">선택한 프로그램을 제거합니다.</system:String>
+    <system:String x:Key="EditProgramTooltip">선택한 프로그램과 인수를 편집합니다.</system:String>
+    <system:String x:Key="MoveProgramUpTooltip">선택한 프로그램을 목록에서 위로 이동합니다. 우클릭하여 맨 위로 이동합니다.</system:String>
+    <system:String x:Key="MoveProgramDownTooltip">선택한 프로그램을 목록에서 아래로 이동합니다. 우클릭하여 맨 아래로 이동합니다.</system:String>
+    <system:String x:Key="BrowseProgramTooltip">실행할 프로그램을 탐색합니다</system:String>
+
+    <system:String x:Key="ResetLauncherDefaultsTooltip">게임 런처 설정을 기본값으로 초기화합니다.</system:String>
+
+    <!--Catalog Creation Window-->
+    <system:String x:Key="CreateMod">모드 생성</system:String>
+    <system:String x:Key="CreateCatalog">카탈로그 생성</system:String>
+    <system:String x:Key="MegaLinkGenerator">Mega 링크 생성기</system:String>
+
+
+    <!--Chunk Tool Window-->
+    <system:String x:Key="SelectFlevelLabel">FLEVEL 선택:</system:String>
+    <system:String x:Key="OutputFolderLabel">출력 폴더:</system:String>
+
+    <system:String x:Key="SectionHeader" xml:space="preserve"> 섹션 # </system:String>
+    <system:String x:Key="Section1">섹션 1 필드 스크립트 대화</system:String>
+    <system:String x:Key="Section2">섹션 2 카메라 행렬</system:String>
+    <system:String x:Key="Section3">섹션 3 모델 로더</system:String>
+    <system:String x:Key="Section4">섹션 4 팔레트</system:String>
+    <system:String x:Key="Section5">섹션 5 워크메시</system:String>
+    <system:String x:Key="Section6">섹션 6 타일맵 (미사용)</system:String>
+    <system:String x:Key="Section7">섹션 7 인카운터</system:String>
+    <system:String x:Key="Section8">섹션 8 트리거</system:String>
+    <system:String x:Key="Section9">섹션 9 배경</system:String>
+
+    <system:String x:Key="Extract">추출</system:String>
+
+
+    <!--Configure Mod Window-->
+    <system:String x:Key="ConfigureHeader" xml:space="preserve"> 설정 </system:String>
+    <system:String x:Key="Preview">미리보기</system:String>
+    <system:String x:Key="Stop">중지</system:String>
+    <system:String x:Key="ResetToModDefaults">모드 기본값으로 초기화</system:String>
+
+    <!--MainWindow.xaml.cs Strings-->
+    <system:String x:Key="AreYouSureYouWantToPlayDebugWarning" xml:space="preserve">이 모드에서 FF7를 플레이하시겠습니까? 이 방식으로 FF7을 플레이하면 심각한 속도 저하가 발생하고 많은 디스크 공간을 사용할 수 있습니다.
+
+이 옵션은 단일 활성 모드 문제를 해결하는 동안에만 사용해야 합니다. 모드 제작자 및/또는 7H 개발자에게 버그 리포트를 제공할 수 있도록 사용하세요.</system:String>
+
+    <system:String x:Key="AreYouSureYouWantToExitPendingDownloads">종료하시겠습니까? 다운로드가 진행 중입니다.</system:String>
+    <system:String x:Key="ConfirmExit">종료 확인</system:String>
+    <system:String x:Key="Exit">종료</system:String>
+
+    <system:String x:Key="CannotExitWhileImporting">현재 모드를 가져오는 중이며 7th Heaven을 닫으면 심각한 손상이 발생할 수 있습니다. 이 작업이 완료될 때까지 기다린 후 다시 시도하세요.</system:String>
+
+    <!--MainWindowViewModel Strings-->
+    <system:String x:Key="StartedClickHereToViewAppLog">시작됨 - 여기를 클릭하여 앱 로그를 확인하세요.</system:String>
+    <system:String x:Key="HintLabel">힌트:</system:String>
+    <system:String x:Key="CheckingForUpdates">앱 업데이트 확인 중 ...</system:String>
+    <system:String x:Key="SelectAll">모두 선택</system:String>
+    <system:String x:Key="Unknown">알 수 없음</system:String>
+
+    <system:String x:Key="UpdateAvailable">업데이트 가능</system:String>
+    <system:String x:Key="UpdateDownloading">업데이트 다운로드 중</system:String>
+
+    <system:String x:Key="NoUpdates">업데이트 없음</system:String>
+    <system:String x:Key="UpdatesIgnored">업데이트 무시됨</system:String>
+    <system:String x:Key="AutoUpdate">자동 업데이트</system:String>
+
+    <system:String x:Key="FollowingErrorsFoundInConfiguration">설정에서 다음 오류가 발견되었습니다:</system:String>
+    <system:String x:Key="ErrorsFoundInGeneralSettingsViewAppLog">일반 설정에서 오류가 발견되었습니다. 오류 세부 정보는 app.log를 확인하세요.</system:String>
+
+    <system:String x:Key="AppUpdateIsAvailableMessage" xml:space="preserve">{0}에 대한 업데이트가 있습니다\n'예'를 클릭하여 새 설치 프로그램을 다운로드하고 업데이트를 시작하세요.\n\n{1} 릴리즈 노트:</system:String>
+    <system:String x:Key="NewVersionAvailable">새 버전 사용 가능!</system:String>
+
+    <system:String x:Key="ThisModContainsDataThatCouldHarm" xml:space="preserve">'{0}'은(는) EXE에 코드를 주입하는 기능이 있습니다. 이 과정은 컴퓨터에 해를 끼치는 데 사용될 수도 있습니다. 안전을 위해 카탈로그에서 직접 제공되는 신뢰할 수 있는 출처의 모드만 활성화하세요.
+
+이 모드를 활성화하시겠습니까?</system:String>
+
+    <system:String x:Key="CannotOpenHelp">도움말을 열 수 없습니다 - Resources/Help/index.html 파일을 찾을 수 없습니다</system:String>
+
+    <system:String x:Key="SubscriptionIsAlreadyAdded">구독 {0}이(가) 이미 추가되어 있습니다.</system:String>
+    <system:String x:Key="AddedToSubscriptions">구독에 {0}을(를) 추가했습니다.</system:String>
+    <system:String x:Key="IrosLinkMayBeFormatedIncorrectly">iros:// 링크 {0}의 형식이 올바르지 않을 수 있습니다. 구독에 추가할 수 없습니다.</system:String>
+
+    <system:String x:Key="FailedToSetBackgroundImageFromTheme">테마에서 배경 이미지를 설정하지 못했습니다.</system:String>
+
+
+    <!--MyModsViewModel Strings-->
+
+    <system:String x:Key="ModRequiresModsIsMissingWarning" xml:space="preserve">이 모드는 다음 모드도 활성화되어 있어야 하지만 찾을 수 없습니다:
+{0}
+해당 모드들을 설치하지 않으면 제대로 작동하지 않을 수 있습니다.</system:String>
+
+    <system:String x:Key="UnsupportedModVersionsWarning" xml:space="preserve">이 모드는 다음 모드들을 필요로 하지만 지원되는 버전이 없습니다:
+{0}
+이 모드들을 업데이트해야 할 수 있습니다.</system:String>
+
+    <system:String x:Key="ThisModRequiresYouActivateFollowingMods" xml:space="preserve">이 모드는 다음 모드들을 활성화해야 합니다:
+{0}
+자동으로 켜집니다.</system:String>
+
+    <system:String x:Key="ModRequiresYouDeactivateTheFollowingMods" xml:space="preserve">이 모드는 다음 모드들을 비활성화해야 합니다:
+{0}
+자동으로 꺼집니다.</system:String>
+
+
+    <system:String x:Key="CannotActivateModBecauseItIsIncompatibleWithOtherMod" xml:space="preserve">이 모드는 {0}과(와) 호환되지 않아 활성화할 수 없습니다. 이 모드를 활성화하려면 {0}을(를) 먼저 비활성화해야 합니다.</system:String>
+
+    <system:String x:Key="CannotActivateModBecauseDependentIsIncompatible" xml:space="preserve">이 모드는 {0}이(가) 활성화되어 있어야 하지만 {0}이(가) {1}과(와) 호환되지 않아 활성화할 수 없습니다. 이 모드를 활성화하려면 {1}을(를) 먼저 비활성화해야 합니다.</system:String>
+
+    <system:String x:Key="MissingRequirements">요구 사항 누락</system:String>
+    <system:String x:Key="UnsupportedVersion">지원되지 않는 버전</system:String>
+    <system:String x:Key="MissingRequiredActiveMods">필수 활성 모드 누락</system:String>
+    <system:String x:Key="DeactivateModsWarning">모드 비활성화 경고</system:String>
+    <system:String x:Key="Uninstalled">제거됨</system:String>
+
+    <system:String x:Key="CanNotReOrderModItHasBeenRemoved">모드 순서를 변경할 수 없습니다. {0}이(가) 파일 시스템에서 제거된 것 같습니다.</system:String>
+    <system:String x:Key="CanNotConfigureModItHasBeenRemoved">모드를 설정할 수 없습니다. {0}이(가) 파일 시스템에서 제거된 것 같습니다.</system:String>
+    <system:String x:Key="CanNotConfigureModFailedToReadModXml">모드 {0}을(를) 설정할 수 없습니다 - mod.xml 읽기 실패</system:String>
+
+    <system:String x:Key="NoOptions">옵션 없음</system:String>
+    <system:String x:Key="ThereAreNoOptionsToConfigureForThisMod">이 모드에 설정할 옵션이 없습니다.</system:String>
+
+    <system:String x:Key="NewVersionOfModAvailable">{0}의 새 버전이 있습니다</system:String>
+
+
+    <!--CatalogViewModel Strings-->
+
+    <system:String x:Key="ThisModAlsoRequiresYouDownloadTheFollowing" xml:space="preserve">이 모드는 다음 모드들도 다운로드해야 합니다:
+{0}
+다운로드 및 설치하시겠습니까?</system:String>
+
+    <system:String x:Key="ThisModRequiresTheFollowingButCouldNotBeFoundInCatalog" xml:space="preserve">이 모드는 다음 모드들도 설치되어 있어야 하지만 카탈로그에서 찾을 수 없습니다:
+{0}
+요구 사항을 찾아 설치하지 않으면 제대로 작동하지 않을 수 있습니다.</system:String>
+
+    <system:String x:Key="PauseResumeSelectedDownload">선택한 다운로드 일시 중지/재개</system:String>
+    <system:String x:Key="PauseSelectedDownload">선택한 다운로드 일시 중지</system:String>
+    <system:String x:Key="ResumeSelectedDownload">선택한 다운로드 재개</system:String>
+
+    <system:String x:Key="NoResultsFound">결과 없음</system:String>
+    <system:String x:Key="CheckingSubscription">구독 확인 중</system:String>
+    <system:String x:Key="CheckingCatalog">카탈로그 확인 중</system:String>
+    <system:String x:Key="UpdatedCatalogFrom">카탈로그 업데이트됨:</system:String>
+    <system:String x:Key="FailedToLoadSubscription">구독 불러오기 실패</system:String>
+    <system:String x:Key="CatalogDownloadFailed">카탈로그 다운로드 실패</system:String>
+
+    <system:String x:Key="Starting">시작 중...</system:String>
+    <system:String x:Key="Pending">대기 중...</system:String>
+    <system:String x:Key="Resuming">재개 중...</system:String>
+    <system:String x:Key="Paused">일시 중지됨...</system:String>
+    <system:String x:Key="Canceled">취소됨</system:String>
+    <system:String x:Key="Failed">실패</system:String>
+
+    <system:String x:Key="IsAlreadyDownloading">이미 다운로드 중입니다!</system:String>
+    <system:String x:Key="IsAlreadyUpdating">이미 업데이트 중입니다!</system:String>
+    <system:String x:Key="IsAlreadyDownloadedAndInstalled">이미 다운로드되어 설치되었습니다!</system:String>
+
+    <system:String x:Key="NoLinksFor">링크 없음:</system:String>
+    <system:String x:Key="FailedToParseLinkFor">링크 파싱 실패:</system:String>
+    <system:String x:Key="OpeningExternalUrlInBrowserFor">브라우저에서 외부 URL 열기:</system:String>
+
+    <system:String x:Key="ErrorDownloading">다운로드 오류</system:String>
+    <system:String x:Key="WasCanceled">취소되었습니다</system:String>
+    <system:String x:Key="Error">오류</system:String>
+
+    <system:String x:Key="ExternalUrlDownloadMessage1" xml:space="preserve">이 모드는 외부 웹 사이트에서 다운로드해야 합니다.
+
+지금 웹 브라우저를 열어 다운로드하시겠습니까?</system:String>
+
+    <system:String x:Key="ExternalUrlDownloadMessage2" xml:space="preserve">모드 자동 다운로드에 실패했습니다. 이 모드를 다운로드할 수 있는 외부 링크가 있습니다.
+
+지금 웹 브라우저를 열어 다운로드하시겠습니까?</system:String>
+
+    <system:String x:Key="SwitchingToBackupUrl">백업 URL로 전환 중</system:String>
+    <system:String x:Key="Downloading">다운로드 중</system:String>
+    <system:String x:Key="Installing">설치 중</system:String>
+
+
+    <!--ChunkToolViewModel Strings-->
+    <system:String x:Key="PathToFlevelRequired">Flevel 경로가 필요합니다.</system:String>
+    <system:String x:Key="PathToOutputFolderRequired">출력 폴더 경로가 필요합니다.</system:String>
+    <system:String x:Key="SelectTheSectionsToExtract">추출할 섹션을 선택하세요.</system:String>
+    <system:String x:Key="FlevelFileDoesNotExistAtGivenPath">주어진 경로에 Flevel 파일이 없습니다.</system:String>
+    <system:String x:Key="OutputFolderDoesNotExist">출력 폴더가 없습니다.</system:String>
+
+    <system:String x:Key="Complete">완료!</system:String>
+    <system:String x:Key="FailedToExtractTheErrorHasBeenLogged">추출 실패. 오류가 기록되었습니다</system:String>
+
+
+    <!--ConfigureModViewModel Strings-->
+    <system:String x:Key="ConfigureMod">모드 설정</system:String>
+
+    <system:String x:Key="ThisOptionCannotBeChangedDueToCompatibility">다른 모드와의 호환성으로 인해 이 옵션을 변경할 수 없습니다</system:String>
+    <system:String x:Key="TheFollowingValuesHaveBeenRemovedDueToCompatibility">다음 값들: {0}이(가) 다른 모드({1})와의 호환성으로 인해 제거되었습니다</system:String>
+
+    <system:String x:Key="FailedToPlayPreviewAudio">미리보기 오디오 재생 실패</system:String>
+
+
+    <!--DownloadItemViewModel Strings-->
+    <system:String x:Key="DownloadingPreviewImage">미리보기 이미지 다운로드 중</system:String>
+
+
+
+    <!--GameLaunchSettingsViewModel Strings-->
+    <system:String x:Key="InsertAndClickImport">{0}을(를) 삽입하고 '가져오기'를 클릭하세요.</system:String>
+    <system:String x:Key="GameLauncherSettingsUpdated">게임 런처 설정이 업데이트되었습니다!</system:String>
+    <system:String x:Key="FailedToSaveLaunchSettings">게임 런처 설정 저장 실패</system:String>
+
+    <system:String x:Key="ErrorCopyingFf7InputCfg">ff7input.cfg 복사 오류</system:String>
+    <system:String x:Key="NoFf7InputCfgFoundAt">다음 위치에서 ff7input.cfg를 찾을 수 없습니다:</system:String>
+    <system:String x:Key="AlreadyExistsAt">이미 다음 위치에 존재합니다:</system:String>
+
+    <system:String x:Key="ChoosingAnyOtherOptionBesidesCustom7HGameDriver">'사용자 정의 7H 게임 드라이버' 외의 다른 옵션을 선택하면 7H로 설치된 모드가 더 이상 작동하지 않습니다!</system:String>
+
+    <system:String x:Key="ReunionWarningMessage" xml:space="preserve">Reunion R06 이상 버전은 Options.ini에서 비활성화되어 있어도 FF7 실행 시 사용자 정의 게임 드라이버를 강제로 로드합니다. 이는 7th Heaven의 게임 드라이버와 충돌하여 그래픽 설정이 깨지고 문제가 발생합니다.
+
+Reunion을 플레이하려면 7th Heaven용으로 제작된 호환 가능한 모드 버전을 사용하세요.
+
+계속하시겠습니까?</system:String>
+
+    <system:String x:Key="YouShouldLeaveThisSettingOn">이 설정을 켜둬야 합니다!</system:String>
+    <system:String x:Key="ProgramToRunNotFound">실행할 프로그램을 찾을 수 없습니다</system:String>
+
+    <system:String x:Key="ImportMissingMoviesWarningMessage" xml:space="preserve">게임 디스크에서 누락된 동영상 파일을 '일반 설정'의 동영상 경로로 복사합니다.
+이 작업은 {0}에 있는 기존 동영상 파일을 덮어씁니다.
+
+계속하시겠습니까?</system:String>
+
+    <system:String x:Key="LookingFor">찾는 중:</system:String>
+    <system:String x:Key="InsertToContinue">계속하려면 {0}을(를) 삽입하세요.</system:String>
+
+    <system:String x:Key="PleaseInsertToContinueCopying" xml:space="preserve">누락된 동영상 파일 복사를 계속하려면 {0}을(를) 삽입하세요.
+
+'취소'를 클릭하면 작업을 중단합니다.</system:String>
+
+    <system:String x:Key="FoundDiscAt">{0}을(를) 다음 위치에서 찾았습니다:</system:String>
+    <system:String x:Key="Overwriting">덮어쓰는 중</system:String>
+    <system:String x:Key="Copying">복사 중</system:String>
+    <system:String x:Key="FailedToFindAt">{1}에서 {0}을(를) 찾지 못했습니다</system:String>
+    <system:String x:Key="AnErrorOccurredCopyingMovies">동영상 복사 중 오류가 발생했습니다</system:String>
+    <system:String x:Key="SuccessfullyCopiedMovies">동영상을 성공적으로 복사했습니다.</system:String>
+    <system:String x:Key="FinishedCopyingMoviesSomeFailed">동영상 복사를 완료했습니다. 일부 동영상 복사에 실패했습니다. 자세한 내용은 앱 로그를 확인하세요.</system:String>
+
+    <system:String x:Key="SaveControlConfiguration">컨트롤 설정 저장</system:String>
+    <system:String x:Key="ImportCurrentControlsFromGameAndSaveAs">게임에서 현재 컨트롤을 가져와 다음 이름으로 저장...</system:String>
+    <system:String x:Key="SaveError">저장 오류</system:String>
+    <system:String x:Key="ControlNameIsEmpty">컨트롤 이름이 비어 있습니다.</system:String>
+    <system:String x:Key="ControlNameContainsInvalidChars">컨트롤 이름에 유효하지 않은 문자가 포함되어 있습니다.</system:String>
+
+    <system:String x:Key="ControlsWithThatNameAlreadyExist">해당 이름의 사용자 정의 컨트롤이 이미 존재합니다.</system:String>
+
+    <system:String x:Key="SuccessfullyCreatedCustomControls">사용자 정의 컨트롤을 성공적으로 생성했습니다.</system:String>
+    <system:String x:Key="FailedToCreateCustomControls">사용자 정의 컨트롤 생성 실패</system:String>
+
+    <system:String x:Key="SuccessfullyDeletedCustomControls">사용자 정의 컨트롤을 성공적으로 삭제했습니다</system:String>
+    <system:String x:Key="FailedToDeleteCustomControls">사용자 정의 컨트롤 삭제 실패</system:String>
+
+
+    <!--GeneralSettingsViewModel Strings-->
+    <system:String x:Key="EnterNameForCatalog">카탈로그 이름을 입력하세요</system:String>
+    <system:String x:Key="GeneralSettingsHaveBeenUpdated">일반 설정이 업데이트되었습니다!</system:String>
+
+    <system:String x:Key="SettingsNotValid">설정이 유효하지 않음</system:String>
+    <system:String x:Key="MissingFf7ExePath">FF7 실행 파일 경로가 누락되었습니다.</system:String>
+    <system:String x:Key="Ff7ExePathChanged">게임 경로 변경이 감지되었습니다. 7th Heaven을 다시 시작하는 것을 강력히 권장합니다. 지금 다시 시작하시겠습니까?</system:String>
+    <system:String x:Key="MissingLibraryPath">라이브러리 경로가 누락되었습니다.</system:String>
+    <system:String x:Key="MissingTexturesPath">텍스처 (Aali OpenGL) 경로가 누락되었습니다.</system:String>
+    <system:String x:Key="MissingMoviePath">동영상 경로가 누락되었습니다.</system:String>
+    <system:String x:Key="LibraryPathCannotBeGameOrApp">라이브러리 경로는 게임이나 7th Heaven에서 사용하는 경로와 같을 수 없습니다. 기본 경로를 사용하거나 다른 경로를 선택하세요.</system:String>
+
+    <system:String x:Key="FailedToRegisterIroModFilesWith7thHeaven">7th Heaven에 .iro 모드 파일 등록 실패</system:String>
+    <system:String x:Key="FailedToUnregisterIroModFilesWith7thHeaven">7th Heaven에서 .iro 모드 파일 등록 해제 실패</system:String>
+    <system:String x:Key="FailedToUnregisterIrosLinksWith7thHeaven">7th Heaven에서 iros:// 링크 등록 해제 실패</system:String>
+    <system:String x:Key="FailedToRegisterIrosLinksWith7thHeaven">7th Heaven에 iros:// 링크 등록 실패</system:String>
+    <system:String x:Key="FailedToCreate7thHeavenContextMenuEntries">Windows 탐색기에 7th Heaven 컨텍스트 메뉴 항목 생성 실패</system:String>
+    <system:String x:Key="FailedToRemove7thHeavenContextMenuEntries">Windows 탐색기에서 7th Heaven 컨텍스트 메뉴 항목 제거 실패</system:String>
+
+    <system:String x:Key="CatalogNameWillAutoResolveOnSave">카탈로그 이름이 저장 시 자동으로 확인됩니다</system:String>
+    <system:String x:Key="ResolvingCatalogName">카탈로그 이름 확인 중 ...</system:String>
+    <system:String x:Key="UrlMustBeInIrosFormat">URL은 iros:// 형식이어야 합니다</system:String>
+    <system:String x:Key="ResolvingCatalogNameFor">카탈로그 이름 확인 중:</system:String>
+
+
+    <!--ImportModViewModel Strings-->
+    <system:String x:Key="SelectAnIroFileToImport">라이브러리 폴더로 가져올 .iro 또는 .irop 파일을 선택하세요.</system:String>
+    <system:String x:Key="SelectAFolderThatContainsModFiles">모드 파일이 포함된 폴더를 선택하세요. 모드 파일이 라이브러리 폴더로 복사됩니다.</system:String>
+    <system:String x:Key="SelectAFolderThatContainsIroModFilesAndFolders">.iro 모드 파일과 모드 폴더가 포함된 폴더를 선택하세요. 발견된 모든 모드 파일이 라이브러리 폴더로 복사됩니다.</system:String>
+    <system:String x:Key="ImportingModsPleaseWait">모드 가져오는 중... 잠시 기다려 주세요 ...</system:String>
+
+    <system:String x:Key="ValidationError">유효성 검사 오류</system:String>
+    <system:String x:Key="ImportError">가져오기 오류</system:String>
+
+    <system:String x:Key="EnterPathToAnIroFile">.iro 파일 경로를 입력하세요.</system:String>
+    <system:String x:Key="IroFileDoesNotExist">.iro 파일이 없습니다.</system:String>
+
+    <system:String x:Key="SuccessfullyImported">성공적으로 가져왔습니다</system:String>
+    <system:String x:Key="CanNotImportMod">모드를 가져올 수 없습니다.</system:String>
+    <system:String x:Key="FailedToImportModTheErrorHasBeenLogged">모드 가져오기 실패. 오류가 기록되었습니다.</system:String>
+
+    <system:String x:Key="EnterPathToFolderContainingModFiles">모드 파일이 포함된 폴더 경로를 입력하세요.</system:String>
+    <system:String x:Key="DirectoryDoesNotExist">디렉토리가 없습니다.</system:String>
+
+    <system:String x:Key="EnterPathToFolderContainingIroFilesOrModFolders">.iro 파일 및/또는 모드 폴더가 포함된 폴더 경로를 입력하세요.</system:String>
+
+    <!--MegaLinkGenUserControl Strings-->
+    <system:String x:Key="GenerateLinks">링크 생성</system:String>
+
+    <!--MegaLinkGenViewModel Strings-->
+    <system:String x:Key="GeneratingLinks">링크 생성 중 ...</system:String>
+    <system:String x:Key="FailedToGenerateLinks">링크 생성 실패</system:String>
+    <system:String x:Key="EnterMegaFolderIdToGenerateLinks">링크를 생성할 Mega 폴더 ID를 입력하세요.</system:String>
+    <system:String x:Key="NoLinksFoundInFolder">폴더에서 링크를 찾을 수 없습니다</system:String>
+
+
+    <!--CreateModUserControl Strings-->
+    <system:String x:Key="Generate">생성</system:String>
+    <system:String x:Key="Info">정보</system:String>
+    <system:String x:Key="MakeSureToCopyToTheRootFolder">미리보기 이미지가 올바르게 로드되도록 {0}을(를) 모드 루트 폴더에 복사하세요.</system:String>
+
+    <!--ModCreationViewModel Strings-->
+    <system:String x:Key="CouldNotLoadModXml">mod xml을 불러올 수 없습니다</system:String>
+    <system:String x:Key="CouldNotSaveModXml">mod xml을 저장할 수 없습니다</system:String>
+    <system:String x:Key="SuccessfullySavedTo">다음 위치에 성공적으로 저장되었습니다:</system:String>
+
+
+    <!--OpenProfileWindow Strings-->
+    <system:String x:Key="LoadProfile">프로필 불러오기</system:String>
+    <system:String x:Key="SaveCurrentProfileAs">현재 프로필을 다른 이름으로 저장...</system:String>
+    <system:String x:Key="CopySelectedProfileToNewProfile">선택한 프로필을 새 프로필로 복사</system:String>
+    <system:String x:Key="DeleteSelectedProfile">선택한 프로필 삭제</system:String>
+    <system:String x:Key="ViewSelectedProfileDetails">선택한 프로필 세부 정보 보기</system:String>
+
+    <system:String x:Key="AreYouSureYouWantToDeleteSelectedProfile">선택한 프로필을 삭제하시겠습니까?</system:String>
+
+    <system:String x:Key="NoProfileSelected">선택한 프로필 없음</system:String>
+    <system:String x:Key="SelectProfileToContinue">계속하려면 프로필을 선택하세요</system:String>
+
+
+    <!--OpenProfileViewModel Strings-->
+    <system:String x:Key="ActiveProfileFileDoesNotExist">활성 프로필 파일이 없습니다</system:String>
+    <system:String x:Key="EnterProfileName">프로필 이름 입력:</system:String>
+    <system:String x:Key="SaveActiveProfile">활성 프로필 저장</system:String>
+    <system:String x:Key="SuccessfullySavedAsNewProfile">{0}을(를) 새 프로필 {1}로 성공적으로 저장했습니다!</system:String>
+    <system:String x:Key="FailToSaveAsNewProfile">{0}을(를) 새 프로필 {1}로 저장 실패: {2}</system:String>
+
+    <system:String x:Key="ProfileDoesNotExist">프로필이 없습니다</system:String>
+    <system:String x:Key="HasItBeenDeletedAlready">이미 삭제되었나요?</system:String>
+    <system:String x:Key="SuccessfullyDeletedProfile">프로필을 성공적으로 삭제했습니다</system:String>
+    <system:String x:Key="FailedToDeleteProfile">프로필 삭제 실패</system:String>
+
+    <system:String x:Key="EnterProfileNameForTheCopy">복사본의 프로필 이름을 입력하세요:</system:String>
+    <system:String x:Key="CopyProfile">프로필 복사</system:String>
+    <system:String x:Key="NewProfile">새 프로필</system:String>
+    <system:String x:Key="SuccessfullyCopiedProfile">프로필 {0}을(를) 새 프로필 {1}로 성공적으로 복사했습니다</system:String>
+    <system:String x:Key="FailedToCopyProfile">프로필 {0}을(를) {1}로 복사 실패</system:String>
+
+    <system:String x:Key="FailedToOpenProfileDetails">프로필 세부 정보 열기 실패</system:String>
+    <system:String x:Key="ProfileNameIsEmpty">프로필 이름이 비어 있습니다.</system:String>
+    <system:String x:Key="ProfileError">프로필 오류</system:String>
+
+    <system:String x:Key="WarningProfileXmlDoesNotExistCanNotSwitch">경고: {0}의 프로필 xml 파일이 없습니다. 프로필을 전환할 수 없습니다!</system:String>
+    <system:String x:Key="LoadedProfile">프로필 불러옴</system:String>
+    <system:String x:Key="FailedToSwitchToProfile">프로필 전환 실패</system:String>
+
+
+    <!--PackIroViewModel Strings-->
+    <system:String x:Key="PathToSourceFolderIsRequired">소스 폴더 경로가 필요합니다</system:String>
+    <system:String x:Key="PathToOutputIroFileIsRequired">출력 iro 파일 경로가 필요합니다</system:String>
+    <system:String x:Key="SelectCompressionOption">압축 옵션을 선택하세요</system:String>
+    <system:String x:Key="InvalidPackIroOptions">유효하지 않은 IRO 패킹 옵션</system:String>
+    <system:String x:Key="AnErrorOccuredWhilePacking">패킹 중 오류가 발생했습니다</system:String>
+    <system:String x:Key="PackingComplete">패킹 완료!</system:String>
+
+
+    <!--PatchIroViewModel Strings-->
+    <system:String x:Key="PathToOriginalIroIsRequired">원본 iro 경로가 필요합니다</system:String>
+    <system:String x:Key="PathToNewIroFileIsRequired">새 iro 파일 경로가 필요합니다</system:String>
+    <system:String x:Key="PathToIropFileIsRequired">저장할 irop 파일 경로가 필요합니다</system:String>
+    <system:String x:Key="AnErrorOccuredWhilePatching">패치 중 오류가 발생했습니다</system:String>
+    <system:String x:Key="PatchingComplete">패치 완료!</system:String>
+
+
+    <!--ThemeSettingsWindow Strings-->
+    <system:String x:Key="ChangeColorThemeWindowTitle">색상 테마 변경</system:String>
+    <system:String x:Key="ExportTheme">테마 내보내기 ...</system:String>
+
+    <!--ThemeSettingsViewModel Strings-->
+    <system:String x:Key="ThemeSaved">테마 저장됨!</system:String>
+    <system:String x:Key="ThemeSavedAs">테마 저장됨:</system:String>
+    <system:String x:Key="FailedToSaveTheme">테마 저장 실패...</system:String>
+    <system:String x:Key="FailedToLoadTheme">테마 불러오기 실패</system:String>
+    <system:String x:Key="ThemeLoadedClickSavveToSaveThis">테마 불러옴! '저장'을 클릭하여 이 테마를 기본값으로 저장하세요 ...</system:String>
+    <system:String x:Key="SelectBackgroundImageFile">배경 이미지 파일 선택</system:String>
+
+
+    <!--UnpackIroViewModel Strings-->
+    <system:String x:Key="PathToSourceIroFileIsRequired">소스 iro 파일 경로가 필요합니다</system:String>
+    <system:String x:Key="InvalidUnpackIroOptions">유효하지 않은 IRO 압축 해제 옵션</system:String>
+    <system:String x:Key="AnErrorOccuredWhileUnpacking">압축 해제 중 오류가 발생했습니다</system:String>
+    <system:String x:Key="UnpackingComplete">압축 해제 완료!</system:String>
+
+
+    <!--CreateCatalogUserControl Strings-->
+    <system:String x:Key="RemoveMod">모드 제거</system:String>
+    <system:String x:Key="Add">추가</system:String>
+
+    <!--CatalogCreationViewModel Strings-->
+    <system:String x:Key="CouldNotLoadModXmlFromIroFile">.iro 파일에서 mod xml을 불러올 수 없습니다</system:String>
+    <system:String x:Key="CouldNotLoadCatalogXml">카탈로그 xml을 불러올 수 없습니다</system:String>
+
+
+    <!--ConfigureGLWindow.xaml.cs Strings-->
+    <system:String x:Key="FailedToReadRequiredSpecXmlFile">설정을 표시하는 데 필요한 spec xml 파일을 읽지 못했습니다. 창을 닫아야 합니다.</system:String>
+    <system:String x:Key="WillDeleteEverythingUnder">다음 경로의 모든 항목을 삭제합니다:</system:String>
+    <system:String x:Key="PathToCacheFolderDoesNotExist">캐시 폴더 경로가 없습니다.</system:String>
+    <system:String x:Key="TextureCacheCleared">텍스처 캐시가 지워졌습니다!</system:String>
+    <system:String x:Key="FailedToClearTextureCache">텍스처 캐시 지우기 실패</system:String>
+    <system:String x:Key="GameDriverSettingsSaved">게임 드라이버 설정이 저장되었습니다!</system:String>
+    <system:String x:Key="CouldNotWriteTo7HGameDriverCfg">FFNx.toml 파일에 쓸 수 없습니다. 읽기 전용으로 설정되어 있지 않은지, FF7이 전체 쓰기 권한이 있는 폴더에 설치되어 있는지 확인하세요.</system:String>
+    <system:String x:Key="UnknownErrorWhileSaving">저장 중 알 수 없는 오류가 발생했습니다. 오류가 기록되었습니다.</system:String>
+    <system:String x:Key="GameDriverSettingsResetToDefaults">게임 드라이버 설정이 기본값으로 초기화되었습니다. '저장'을 클릭하여 변경 사항을 저장하세요.</system:String>
+
+
+
+    <!--GameLaunchSettingsWindow.xaml.cs Strings-->
+    <system:String x:Key="SelectProgramToRemove">제거할 프로그램을 선택하세요.</system:String>
+    <system:String x:Key="SelectProgramToEdit">편집할 프로그램을 선택하세요.</system:String>
+    <system:String x:Key="SelectProgramToMove">이동할 프로그램을 선택하세요.</system:String>
+    <system:String x:Key="SelectProgramToRunSuchAs">.exe 또는 스크립트와 같이 실행할 프로그램을 선택하세요</system:String>
+
+
+    <!--GameLaunchWindow.xaml.cs Strings-->
+    <system:String x:Key="LaunchingFinalFantasyVII">Final Fantasy VII 실행 중</system:String>
+    <system:String x:Key="UnknownErrorWhenLaunchingGame">게임 실행 중 알 수 없는 오류가 발생했습니다</system:String>
+    <system:String x:Key="GameLaunchProcessCanceled">게임 실행 프로세스 취소됨</system:String>
+    <system:String x:Key="FailedToLaunchFf7ViewLogForDetails">FF7 실행 실패. 위의 로그에서 자세한 내용을 확인하세요.</system:String>
+    <system:String x:Key="SuccessfullyLaunchedFf7">FF7을 성공적으로 실행했습니다!</system:String>
+
+
+    <!--GeneralSettingsWindow Strings-->
+    <system:String x:Key="ActivateNewlyInstalledModsAutomatically">새로 설치된 모드 자동 활성화</system:String>
+    <system:String x:Key="ImportModsFromLibraryAutomatically">라이브러리에서 모드 자동 가져오기</system:String>
+    <system:String x:Key="WarnWhenModContainsCode">모드에 코드가 포함된 경우 경고</system:String>
+    <system:String x:Key="AutoSortModsByDefault">기본적으로 모드 자동 정렬</system:String>
+    <system:String x:Key="AutoUpdateModsByDefault">기본적으로 모드 자동 업데이트</system:String>
+    <system:String x:Key="IgnoreModCompatibilityRestrictions">모드 호환성 제한 무시</system:String>
+    <system:String x:Key="CheckFor7thHeavenUpdatesAutomatically">7th Heaven 업데이트 자동 확인</system:String>
+
+    <system:String x:Key="OpenIrosLinksWith7thHeaven">7th Heaven으로 iros:// 링크 열기</system:String>
+    <system:String x:Key="OpenModFilesWith7thHeaven">7th Heaven으로 모드 파일 열기</system:String>
+    <system:String x:Key="ContextMenuInExplorer">탐색기에서 컨텍스트 메뉴</system:String>
+
+    <system:String x:Key="PathsHeader" xml:space="preserve"> 경로 </system:String>
+    <system:String x:Key="ShellIntegrationHeader" xml:space="preserve"> 셸 통합 </system:String>
+    <system:String x:Key="CatalogSubscriptionsHeader" xml:space="preserve"> 카탈로그 구독: </system:String>
+    <system:String x:Key="AdditionalFoldersToMonitorHeader" xml:space="preserve"> 모니터링할 추가 폴더: </system:String>
+
+    <system:String x:Key="Url">Url</system:String>
+
+    <system:String x:Key="ErrorIncorrectExe">오류 - 잘못된 실행 파일</system:String>
+    <system:String x:Key="ThisExeIsUsedForSteamReleaseFailedToCopyExe">이 실행 파일은 7th Heaven이 지원하지 않는 FF7 Steam 버전에 사용됩니다. 1.02 패치 ff7.exe 복사에 실패하여 자동으로 선택할 수 없었습니다.</system:String>
+    <system:String x:Key="ThisExeIsUsedForSteamReleaseCopiedSelectedForYou">이 실행 파일은 7th Heaven이 지원하지 않는 FF7 Steam 버전에 사용됩니다. 7th Heaven이 올바르게 작동하도록 1.02 패치 ff7.exe가 {0}되었습니다.</system:String>
+    <system:String x:Key="Selected">선택됨</system:String>
+    <system:String x:Key="CopiedAndSelected">복사 및 선택됨</system:String>
+    <system:String x:Key="ThisExeIsUsedForConfiguringFf7Settings">이 실행 파일은 FF7 설정을 구성하는 데 사용되며 올바른 게임 실행 파일이 아닙니다. 다른 FF7 EXE 파일을 선택하세요.</system:String>
+
+    <system:String x:Key="SelectFf7Exe">FF7.exe 선택</system:String>
+    <system:String x:Key="SelectMoviesFolder">동영상 폴더 선택</system:String>
+    <system:String x:Key="SelectTexturesFolder">텍스처 폴더 선택</system:String>
+    <system:String x:Key="Select7thHeavenLibraryFolder">7th Heaven 라이브러리 폴더 선택</system:String>
+
+    <system:String x:Key="SelectSubscriptionToEdit">편집할 구독을 선택하세요.</system:String>
+    <system:String x:Key="SelectSubscriptionToRemove">제거할 구독을 선택하세요.</system:String>
+    <system:String x:Key="SelectSubscriptionToMove">이동할 구독을 선택하세요.</system:String>
+
+    <system:String x:Key="SelectFolderToRemove">제거할 폴더를 선택하세요.</system:String>
+    <system:String x:Key="SelectFolderToMove">이동할 폴더를 선택하세요.</system:String>
+
+
+    <!--ImportModWindow Strings-->
+    <system:String x:Key="FromIROFile">IRO 파일에서</system:String>
+    <system:String x:Key="FromFolder">폴더에서</system:String>
+    <system:String x:Key="BatchImport">일괄 가져오기</system:String>
+    <system:String x:Key="SelectIroFile">.iro 파일 선택</system:String>
+
+
+    <!--IroCreateWindow Strings-->
+    <system:String x:Key="PackIRO">IRO 패킹</system:String>
+    <system:String x:Key="UnpackIRO">IRO 압축 해제</system:String>
+    <system:String x:Key="PatchIRO">IRO 패치</system:String>
+    <system:String x:Key="PatchIROAdvanced">IRO 패치 (고급)</system:String>
+
+
+    <!--UnhandledErrorWindow Strings-->
+    <system:String x:Key="AnUnhandledExceptionOccurredAppMustClose">처리되지 않은 예외가 발생하여 앱을 닫아야 합니다.</system:String>
+
+
+    <system:String x:Key="SelectLanguage">언어 선택:</system:String>
+    <system:String x:Key="English">영어</system:String>
+    <system:String x:Key="French">프랑스어</system:String>
+    <system:String x:Key="German">독일어</system:String>
+    <system:String x:Key="Spanish">스페인어</system:String>
+    <system:String x:Key="Japanese">일본어</system:String>
+    <system:String x:Key="SimplifiedChinese">중국어 간체</system:String>
+    <system:String x:Key="Korean">한국어</system:String>
+
+
+    <!--GameLauncher Strings-->
+    <system:String x:Key="CheckingFf7IsNotRunning">FF7이 실행 중이지 않은지 확인 중 ...</system:String>
+    <system:String x:Key="Ff7IsAlreadyRunning">FF7이 이미 실행 중입니다!</system:String>
+    <system:String x:Key="Ff7IsAlreadyRunningDoYouWantToForceClose" xml:space="preserve">FF7이 이미 실행 중입니다. 강제로 닫으시겠습니까?
+
+'예'를 클릭하면 현재 실행 중인 모든 FF7 인스턴스를 닫습니다. '아니오'를 클릭하면 다른 인스턴스를 시작합니다.</system:String>
+
+    <system:String x:Key="ForceClosingAllInstancesFf7">모든 FF7 인스턴스를 강제로 닫는 중 ...</system:String>
+    <system:String x:Key="Aborting">중단 중 ...</system:String>
+    <system:String x:Key="FailedToCloseProcess">프로세스 닫기 실패</system:String>
+    <system:String x:Key="CheckingFf7ExeExistsAt">다음 위치에 FF7 .exe가 있는지 확인 중:</system:String>
+    <system:String x:Key="CheckingFF7SteamInstalledCorrectly">FF7 Steam이 올바르게 설치되었는지 확인 중...</system:String>
+    <system:String x:Key="FF7SteamNotInstalledCorrectly" xml:space="preserve">사용자 구성을 찾을 수 없습니다. Steam 게임 설치가 아직 실행되지 않은 것 같습니다.
+
+7th Heaven이 이제 원래 게임을 실행합니다. '플레이'를 클릭하여 게임을 최소한 한 번 실행해 주세요.
+
+완료 후 게임과 런처를 닫고 7th Heaven에서 다시 '플레이'를 클릭하세요.</system:String>
+    <system:String x:Key="FileNotFoundAborting">파일을 찾을 수 없습니다. 중단 중 ...</system:String>
+    <system:String x:Key="Ff7ExeNotFoundYouMayNeedToConfigure">FF7.exe를 찾을 수 없습니다. 설정 > 일반 설정 메뉴에서 7H를 구성해야 할 수 있습니다.</system:String>
+    <system:String x:Key="VerifyingInstalledGameIsCompatible">설치된 게임의 호환성 확인 중 ...</system:String>
+    <system:String x:Key="ErrorCodeYarr">EXE/DLL 무결성 검사 실패. CD/GOG에서 다시 설치하거나 "파일 확인"으로 복구하세요.</system:String>
+    <system:String x:Key="VerifyingGameIsNotInstalledInProtectedFolder">게임이 시스템/보호된 폴더에 설치되어 있지 않은지 확인 중 ...</system:String>
+
+    <system:String x:Key="Ff7IsCurrentlyInstalledInASystemFolder" xml:space="preserve">FF7이 현재 시스템 폴더에 설치되어 있어 모드가 작동하지 않을 수 있습니다. C:\Games\Final Fantasy VII에 설치하는 것을 권장합니다
+
+설치를 C:\Games\Final Fantasy VII로 자동으로 복사하여 계속하시겠습니까?</system:String>
+
+    <system:String x:Key="CanNotContinueDueToFf7nstalledInProtectedFolder">FF7이 시스템/보호된 폴더에 설치되어 있어 계속할 수 없습니다. 중단 중...</system:String>
+    <system:String x:Key="CannotContinue">계속할 수 없습니다!</system:String>
+
+    <system:String x:Key="CopyingGameFilesTo">게임 파일 복사 중:</system:String>
+    <system:String x:Key="FailedToCopyFf7To">FF7 복사 실패:</system:String>
+
+    <system:String x:Key="VerifyingGameIsMaxInstall">게임이 전체/최대 설치인지 확인 중 ...</system:String>
+    <system:String x:Key="YourFf7InstallationFolderIsMissingCriticalFiles" xml:space="preserve">FF7 설치 폴더에 중요한 파일이 누락되어 있습니다. FF7 설치 시 실수로 '표준 설치'를 선택했을 수 있으나 '최대 설치'가 필요합니다.
+
+7th Heaven이 자동으로 수정할 수 있습니다. 게임 디스크 중 하나를 삽입하고 다시 시도하세요.</system:String>
+
+    <system:String x:Key="CreatingMissingRequiredDirectories">누락된 필수 디렉토리 생성 중 ...</system:String>
+    <system:String x:Key="VerifyingAdditionalFilesForBattleAndKernelFoldersExist">'battle'과 'kernel' 폴더에 대한 추가 파일이 있는지 확인 중 ...</system:String>
+    <system:String x:Key="FailedToVerifyCopyMissingAdditionalFiles">누락된 추가 파일 확인/복사 실패. 중단 중...</system:String>
+
+    <system:String x:Key="VerifyingAllMovieFilesExist">모든 동영상 파일이 있는지 확인 중 ...</system:String>
+    <system:String x:Key="CouldNotFindAllMovieFilesAt">다음 위치에서 모든 동영상 파일을 찾을 수 없습니다:</system:String>
+    <system:String x:Key="AllFilesFoundAt">다음 위치에서 모든 파일을 찾았습니다:</system:String>
+    <system:String x:Key="UpdatingMoviePathSetting">동영상 경로 설정 업데이트 중.</system:String>
+    <system:String x:Key="AttemptingToCopyMovieFiles">동영상 파일 복사 시도 중 ...</system:String>
+
+    <system:String x:Key="MovieFilesAreMissing">동영상 파일이 누락되었습니다!</system:String>
+    <system:String x:Key="InOrderToSeeInGameMoviesYouWillNeedMessage" xml:space="preserve">게임 내 동영상을 보려면 동영상 모드를 다운로드하여 활성화해야 합니다.
+
+또는 설정 > 게임 런처... > 디스크에서 동영상 가져오기를 통해 디스크에서 동영상 파일을 가져올 수 있습니다.
+
+마지막으로 '일반 설정'에서 동영상 경로를 게임 디스크의 'FF7\Movies' 폴더로 설정할 수 있지만 게임 중 디스크를 교체해야 합니다.</system:String>
+
+    <system:String x:Key="VerifyingMusicFilesExist">음악 파일이 있는지 확인 중 ...</system:String>
+    <system:String x:Key="CouldNotFindAllMusicFilesAt">다음 위치에서 모든 음악 파일을 찾을 수 없습니다:</system:String>
+    <system:String x:Key="AttemptingToCopyMusicFiles">음악 파일 복사 시도 중 ...</system:String>
+
+    <system:String x:Key="OggMusicFilesAreMissing">.OGG 음악 파일이 누락되었습니다!</system:String>
+    <system:String x:Key="InOrderToHearHighQualityMusicYouWillNeedMessage" xml:space="preserve">고품질 배경 음악을 듣려면 음악 모드를 다운로드하여 활성화해야 합니다.
+
+또는 게임의 원래 저품질 MIDI 음악을 들을 수 있지만, 설정 > 게임 드라이버... > 고급 탭에서 '음악 옵션'으로 '원본 MIDI'를 선택해야 합니다.
+
+나중에 고품질 .OGG 파일을 사용하려면 설정을 'VGMstream'으로 다시 전환하세요.</system:String>
+
+    <system:String x:Key="VerifyingLatestGameDriverIsInstalled">최신 게임 드라이버가 설치되어 있는지 확인 중 ...</system:String>
+    <system:String x:Key="SomethingWentWrongTryingToDetectGameDriver">게임 드라이버 감지/설치 중 문제가 발생했습니다. 중단 중 ...</system:String>
+    <system:String x:Key="VerifyingGameDriverShadersFoldersExist">게임 드라이버 셰이더 폴더가 있는지 확인 중 ...</system:String>
+
+    <system:String x:Key="VerifyingFf7Exe">ff7 exe 확인 중 ...</system:String>
+    <system:String x:Key="VerifyingFf7LauncherExe">FF7_Launcher exe 확인 중 ...</system:String>
+    <system:String x:Key="Ff7ExeDetectedToBeDifferent">ff7.exe가 다른 것으로 감지되었습니다. 백업을 생성하고 올바른 .exe를 복사 중 ...</system:String>
+    <system:String x:Key="FailedToCopyFf7Exe">ff7.exe 복사 실패. 중단 중 ...</system:String>
+    <system:String x:Key="FailedToCreateBackupOfFf7Exe">ff7.exe 백업 생성 실패. 중단 중 ...</system:String>
+
+    <system:String x:Key="Ff7ConfigExeDetectedToBeMissingOrDifferent">FF7Config.exe가 누락되었거나 다른 것으로 감지되었습니다. 백업(있는 경우) 생성 후 올바른 .exe를 복사 중 ...</system:String>
+    <system:String x:Key="FailedToCopyFf7ConfigExe">FF7Config.exe 복사 실패. 중단 중 ...</system:String>
+    <system:String x:Key="FailedToCreateBackupOfFf7ConfigExe">FF7Config.exe 백업 생성 실패. 중단 중 ...</system:String>
+
+    <system:String x:Key="CheckingAProfileIsActive">프로필이 활성화되어 있는지 확인 중 ...</system:String>
+    <system:String x:Key="ActiveProfileNotFound">활성 프로필을 찾을 수 없습니다. 중단 중 ...</system:String>
+    <system:String x:Key="CreateAProfileFirstAndTryAgain">설정 > 프로필에서 먼저 프로필을 생성하고 다시 시도하세요.</system:String>
+
+    <system:String x:Key="CheckingModCompatibilityRequirements">모드 호환성 요구 사항 확인 중 ...</system:String>
+    <system:String x:Key="FailedModCompatibilityCheck">모드 호환성 검사 실패. 중단 중 ...</system:String>
+
+    <system:String x:Key="CheckingModConstraintsForCompatibility">호환성을 위한 모드 제약 조건 확인 중 ...</system:String>
+    <system:String x:Key="FailedModConstraintCheck">모드 제약 조건 검사 실패. 중단 중 ...</system:String>
+
+    <system:String x:Key="CheckingModLoadOrderRequirements">모드 로드 순서 요구 사항 확인 중 ...</system:String>
+    <system:String x:Key="FailedModLoadOrderCheck">모드 로드 순서 검사 실패. 중단 중 ...</system:String>
+
+    <system:String x:Key="LookingForGameDisc">게임 디스크 찾는 중 ...</system:String>
+    <system:String x:Key="FoundGameDiscAt">다음 위치에서 게임 디스크를 찾았습니다:</system:String>
+    <system:String x:Key="FailedToFindGameDisc">게임 디스크 찾기 실패 ...</system:String>
+    <system:String x:Key="OsDoesNotSupportAutoMounting">OS가 가상 디스크 자동 마운트를 지원하지 않습니다. FF7DISC1.ISO라는 가상 디스크를 마운트하거나, FF7DISC1이라는 USB 플래시 드라이브를 삽입하거나, 하드 드라이브 이름을 FF7DISC1로 바꿔야 합니다 ...</system:String>
+    <system:String x:Key="AutoMountingVirtualGameDisc">가상 게임 디스크 자동 마운트 중 ...</system:String>
+    <system:String x:Key="FailedToAutoMountVirtualDiscAt">다음 위치에서 가상 디스크 자동 마운트 실패:</system:String>
+    <system:String x:Key="LookingForGameDiscAfterMounting">마운트 후 게임 디스크 찾는 중 ...</system:String>
+    <system:String x:Key="FailedToFindGameDiscAfterAutoMounting">자동 마운트 후 게임 디스크 찾기 실패 ...</system:String>
+
+    <system:String x:Key="UserRequestedToPlayWithNoModsLaunchingGameAsVanilla">사용자가 모드 없이 플레이를 요청했습니다. '바닐라' 상태로 게임을 실행합니다 ...</system:String>
+    <system:String x:Key="NoModsActivatedLaunchingGameAsVanilla">활성화된 모드가 없습니다. '바닐라' 상태로 게임을 실행합니다 ...</system:String>
+    <system:String x:Key="SelectedRendererIsNotSetToCustomLaunchingGameAsVanilla">선택한 렌더러가 '사용자 정의 7H 게임 드라이버'로 설정되어 있지 않습니다. '바닐라' 상태로 게임을 실행합니다 ...</system:String>
+
+    <system:String x:Key="CreatingRuntimeProfile">런타임 프로필 생성 중 ...</system:String>
+    <system:String x:Key="FailedToCreateRuntimeProfileForActiveMods">활성 모드에 대한 런타임 프로필 생성 실패 ...</system:String>
+
+    <system:String x:Key="VariableDumpSetToTrueStartingTurboLog">변수 덤프가 true로 설정되었습니다. TurBoLog를 시작하는 중 ...</system:String>
+    <system:String x:Key="CopyingEasyHookToFf7PathIfNotFoundOrOlder">FF7 경로에 AppLoader.dll 복사 중 (찾을 수 없거나 이전 버전이 감지된 경우) ...</system:String>
+
+    <system:String x:Key="CopyingFf7InputCfgToFf7Path">FF7 경로에 ff7input.cfg 복사 중 ...</system:String>
+    <system:String x:Key="DebugLoggingSetToTrueDetailedLoggingWillBeWrittenTo">디버그 로깅이 true로 설정되었습니다. 자세한 로그가 다음 위치에 기록됩니다:</system:String>
+
+    <system:String x:Key="CheckingIfReunionModIsInstalled">Reunion 모드가 설치되어 있는지 확인 중 ...</system:String>
+    <system:String x:Key="Found">발견됨</system:String>
+    <system:String x:Key="DisablingReunionMod">Reunion 모드 비활성화 중 (ddraw.dll → Reunion.dll.bak으로 이름 변경) ...</system:String>
+    <system:String x:Key="ReenablingReunionMod">Reunion 모드 다시 활성화 중 (Reunion.dll.bak → ddraw.dll로 이름 변경) ...</system:String>
+
+    <system:String x:Key="LaunchingAdditionalProgramsToRunIfAny">추가 프로그램 실행 중 (있는 경우) ...</system:String>
+    <system:String x:Key="WritingTemporaryRuntimeProfileFileTo">임시 런타임 프로필 파일 작성 중:</system:String>
+
+    <system:String x:Key="AttemptingToInjectWithEasyHook">AppLoader로 주입 시도 중 ...</system:String>
+    <system:String x:Key="ReceivedErrors">오류 수신됨</system:String>
+    <system:String x:Key="ReachedTimeoutWaitingForInjection">주입 대기 시간 초과 ...</system:String>
+    <system:String x:Key="ReceivedUnknownError">알 수 없는 오류 수신됨</system:String>
+    <system:String x:Key="FailedToInjectAfterMaxAmountOfTries">최대 시도 횟수 후 주입 실패</system:String>
+
+    <system:String x:Key="ErrorFailedToStartGame">오류 - 게임 시작 실패</system:String>
+    <system:String x:Key="FailedToInjectWithEasyHookMessage" xml:space="preserve">여러 번 시도 후 AppLoader 주입에 실패했습니다. 게임 런처 설정에서 '코드 5 수정'을 '켜기'로 설정하면 일반적으로 해결됩니다.
+
+설정을 적용하고 다시 시도하시겠습니까?</system:String>
+
+    <system:String x:Key="SettingCompatibilityFixAndTryingAgain">호환성 수정 설정 후 다시 시도 중 ...</system:String>
+    <system:String x:Key="StillFailedToInjectWithEasyHookAborting">호환성 수정 설정 후에도 AppLoader 주입에 여전히 실패했습니다. 중단 중 ...</system:String>
+    <system:String x:Key="FailedToInjectWithEasyHookAfterSettingFlags">호환성 플래그 설정 후에도 AppLoader 주입에 실패했습니다</system:String>
+    <system:String x:Key="UserChoseNotToSetCompatibilityFix">사용자가 호환성 수정 설정을 선택하지 않았습니다. 중단 중 ...</system:String>
+
+    <system:String x:Key="GettingFf7Proc">FF7 프로세스 가져오는 중 ...</system:String>
+    <system:String x:Key="FailedToGetFf7Proc">FF7 프로세스 가져오기 실패. 중단 중 ...</system:String>
+    <system:String x:Key="DebugLoggingSetToTrueWiringUpLogFile">디버그 로깅이 true로 설정되었습니다. 게임 종료 후 열 로그 파일 연결 중 ...</system:String>
+    <system:String x:Key="FailedToStartProcessForDebugLog">디버그 로그용 프로세스 시작 실패</system:String>
+
+    <system:String x:Key="StartingProgramsForMods">모드용 프로그램 시작 중 ...</system:String>
+    <system:String x:Key="StartingPluginsForMods">모드용 플러그인 시작 중 ...</system:String>
+    <system:String x:Key="SettingUpFf7ExeToStopPluginsAndModPrograms">종료 후 플러그인 및 모드 프로그램을 중지하도록 FF7 .exe 설정 중 ...</system:String>
+
+    <system:String x:Key="StoppingOtherProgramsForMods">7H가 시작한 모드용 다른 프로그램 중지 중 ...</system:String>
+    <system:String x:Key="AutoUnmountingGameDisc">게임 디스크 자동 마운트 해제 중 ...</system:String>
+
+    <system:String x:Key="WaitingForFf7ExeToRespond">FF7 .exe 응답 대기 중 (최대 {0}초) ...</system:String>
+    <system:String x:Key="ExceptionOccurredWhileTryingToStart">FF7 시작 시도 중 예외 발생 ...</system:String>
+
+    <system:String x:Key="PluginAdded">플러그인 추가됨</system:String>
+    <system:String x:Key="StartingPlugin">플러그인 시작 중</system:String>
+
+    <system:String x:Key="FailedToGetListOfRuntimeMods">모드의 누락된 변수로 인해 런타임 모드 목록 가져오기 실패</system:String>
+    <system:String x:Key="AddingPathsToMonitor">모니터링할 경로 추가 중 ...</system:String>
+
+    <system:String x:Key="DetectedToBeOlderVersion">이전 버전으로 감지됨</system:String>
+    <system:String x:Key="Copied">복사됨</system:String>
+    <system:String x:Key="SkippedCopying">복사 건너뜀</system:String>
+
+    <system:String x:Key="AnExceptionOccurredTryingToStartFf7At">다음 위치에서 FF7 시작 시도 중 예외 발생:</system:String>
+
+    <system:String x:Key="ThereWasAnErrorVerifyingModConstraintSeeTheFollowingDetails">모드 제약 조건 확인 중 오류가 발생했습니다. 다음 세부 정보를 확인하세요:</system:String>
+    <system:String x:Key="TheFollowingSettingsHaveBeenChangedToMakeTheseModsCompatible">이 모드들이 호환되도록 다음 설정이 변경되었습니다:</system:String>
+
+    <system:String x:Key="ModRequiresYouToActivateAsWell">모드 {0}은(는) {1}도 활성화해야 합니다.</system:String>
+    <system:String x:Key="ModRequiresYouToActivateButYouDoNotHaveCompatibleVersionInstalled">모드 {0}은(는) {1}을(를) 활성화해야 하지만 호환 가능한 버전이 설치되어 있지 않습니다. 업데이트해 보시겠습니까?</system:String>
+    <system:String x:Key="UnsupportedModVersion">지원되지 않는 모드 버전</system:String>
+
+    <system:String x:Key="IncompatibleMod">호환되지 않는 모드</system:String>
+    <system:String x:Key="ModIsNotCompatibleWithTheVersionYouHaveInstalled">모드 {0}은(는) 설치된 {1} 버전과 호환되지 않습니다. 업데이트해 보시겠습니까?</system:String>
+    <system:String x:Key="ModIsNotCompatibleWithYouWillNeedToDisableIt">모드 {0}은(는) {1}과(와) 호환되지 않습니다. 비활성화해야 합니다.</system:String>
+    <system:String x:Key="ModIsNotCompatibleAnotherModVariableUsed">모드 {0}은(는) '{2}' 변수가 둘 다에 정의되어 있어 {1} 모드와 호환되지 않습니다. 둘 중 하나를 비활성화해야 합니다.</system:String>
+
+    <system:String x:Key="TheFollowingModsWillNotWorkProperlyInTheCurrentOrder">다음 모드들은 현재 순서에서 제대로 작동하지 않습니다. 그래도 계속하시겠습니까?</system:String>
+    <system:String x:Key="LoadOrderIncompatible">로드 순서 비호환</system:String>
+    <system:String x:Key="ModIsMeantToComeBelowModInTheLoadOrder">모드 {0}은(는) 로드 순서에서 모드 {1} 아래에 위치해야 합니다</system:String>
+    <system:String x:Key="ModIsMeantToComeAboveModInTheLoadOrder">모드 {0}은(는) 로드 순서에서 모드 {1} 위에 위치해야 합니다</system:String>
+
+    <system:String x:Key="CouldNotFindDdrawDllAt">다음 위치에서 ddraw.dll을 찾을 수 없습니다:</system:String>
+    <system:String x:Key="CouldNotFindReunionDllBakAt">다음 위치에서 Reunion.dll.bak을 찾을 수 없습니다:</system:String>
+    <system:String x:Key="Renamed">이름 변경됨</system:String>
+
+    <system:String x:Key="ApplyingChangedValuesToRegistry">레지스트리에 변경된 값 적용 중 ...</system:String>
+    <system:String x:Key="ApplyingCompatibilityFlagsInRegistry">레지스트리에 호환성 플래그 적용 중 (있는 경우) ...</system:String>
+    <system:String x:Key="CompatibilityFlagsFoundDeleting">호환성 플래그 발견됨 - 삭제 중</system:String>
+    <system:String x:Key="HighDpiFixSetToTrueApplyingCompatibilityFlag">고DPI 수정이 true로 설정됨 - 레지스트리에 HIGHDPIAWARE 호환성 플래그 적용 중</system:String>
+
+    <system:String x:Key="UsingControlConfigurationFile">컨트롤 설정 파일 사용 중</system:String>
+    <system:String x:Key="InputCfgFileNotFoundAt">다음 위치에서 입력 cfg 파일을 찾을 수 없습니다:</system:String>
+    <system:String x:Key="FailedToCopyCfgFile">.cfg 파일 복사 실패</system:String>
+
+    <system:String x:Key="StartingProgram">프로그램 시작 중</system:String>
+    <system:String x:Key="Started">시작됨 ...</system:String>
+    <system:String x:Key="WaitingForProgramToInitializeAndShow">프로그램 초기화 및 표시 대기 중 ...</system:String>
+    <system:String x:Key="TimeoutReachedWaitingForProgramToShow">프로그램 표시 대기 시간 초과 ({0}초). 계속합니다...</system:String>
+    <system:String x:Key="ProgramAlreadyRunning">프로그램이 이미 실행 중</system:String>
+
+
+    <!--GameConverter Class Strings-->
+    <system:String x:Key="NotFoundScanningDiscsForFiles">찾을 수 없습니다. 디스크에서 파일 검색 중 ...</system:String>
+    <system:String x:Key="FoundFileOnAtCopyingFile">{0}의 {1}에서 파일을 찾았습니다. 파일 복사 중 ...</system:String>
+    <system:String x:Key="FailedToCopyErrorHasBeenLogged">복사 실패. 오류가 기록되었습니다</system:String>
+    <system:String x:Key="FailedToFindOnAnyDisc">어느 디스크에서도 {0}을(를) 찾지 못했습니다 ...</system:String>
+    <system:String x:Key="FileNotFound">파일을 찾을 수 없습니다...</system:String>
+    <system:String x:Key="CannotCopySourceFileBecauseItIsMissingAt">다음 위치에서 소스 파일이 누락되어 복사할 수 없습니다:</system:String>
+    <system:String x:Key="CopyingFileFrom">파일 복사 중:</system:String>
+
+    <system:String x:Key="CannotCheckIfLatestDriverIsInstalledDueToMissingFile">파일 누락으로 인해 최신 드라이버 설치 여부를 확인할 수 없습니다</system:String>
+    <system:String x:Key="GameDriverDllFileIsUpToDate">FFNx.dll 파일이 최신 버전입니다.</system:String>
+    <system:String x:Key="BackingUpExistingGameDriverTo">기존 게임 드라이버를 다음 위치에 백업 중:</system:String>
+    <system:String x:Key="BackingUpExistingGameDriverCfgTo">기존 게임 드라이버 .cfg를 다음 위치에 백업 중:</system:String>
+    <system:String x:Key="GameDriverCfgFileMissingCopyingDefaultFrom">FFNx.toml 파일이 없습니다. 다음 위치에서 기본값 복사 중:</system:String>
+    <system:String x:Key="CannotCreateDefaultCfgDueToMissingFile">파일 누락으로 인해 기본 .cfg를 생성할 수 없습니다</system:String>
+    <system:String x:Key="BackingUpExistingShadersFolderTo">기존 'shaders' 폴더를 다음 위치에 백업 중:</system:String>
+    <system:String x:Key="CopyingContentsOf">다음의 내용 복사 중:</system:String>
+    <system:String x:Key="DirectoryMissingCreating">디렉토리 누락. 생성 중</system:String>
+    <system:String x:Key="OldGameConverterRegistryKeysFoundBackingUp">이전 게임 컨버터 레지스트리 키를 찾았습니다. 이전 컨버터 파일 및 레지스트리 백업 중 ...</system:String>
+
+    <system:String x:Key="MissingShadersNolightFolderCreatingDirectory">shaders/nolight 폴더 누락. 디렉토리 생성 중 ...</system:String>
+    <system:String x:Key="MissingShadersComplexMultiShaderFolderCreatingDirectory">shaders/ComplexMultiShader_Nvidia 폴더 누락. 디렉토리 생성 중 ...</system:String>
+    <system:String x:Key="MissingShadersFolderCreatingDirectory">shaders 폴더 누락. Resources/Game Driver/에서 복사 중 ...</system:String>
+    <system:String x:Key="MissingShadersFilesCopyingFrom">셰이더 파일 누락: {0}. {1}에서 복사 중 ...</system:String>
+
+
+    <!--UpdateChecker Class Strings-->
+    <system:String x:Key="CheckingForUpdatesUsingChannel">다음 채널을 사용하여 업데이트 확인 중:</system:String>
+    <system:String x:Key="FailedToCheckForUpdatesAt">다음 위치에서 업데이트 확인 실패:</system:String>
+
+
+    <!--ConfigureGLWindow.xaml.cs Strings-->
+    <system:String x:Key="Graphics">그래픽</system:String>
+    <system:String x:Key="Controls">컨트롤</system:String>
+    <system:String x:Key="Rendering">렌더링</system:String>
+    <system:String x:Key="Cheats">치트</system:String>
+    <system:String x:Key="Advanced">고급</system:String>
+
+    <!--FileUtils.cs Strings-->
+    <system:String x:Key="FailedToCopyDirectory">디렉토리 복사 실패</system:String>
+    <system:String x:Key="FailedToMoveDirectory">디렉토리 이동 실패</system:String>
+    <system:String x:Key="FailedToDeleteFiles">파일 삭제 실패</system:String>
+
+    <system:String x:Key="FailedToGetPreviewImage">미리보기 이미지 가져오기 실패</system:String>
+
+    <system:String x:Key="ErrorOccurredDownloadingInstalling">다운로드/설치 중 오류 발생</system:String>
+
+    <system:String x:Key="Installed">설치됨</system:String>
+    <system:String x:Key="Updated">업데이트됨</system:String>
+    <system:String x:Key="ErrorUpdating">업데이트 오류</system:String>
+
+    <system:String x:Key="FailedToGetModInfoDueToMissingVariable">경고: 누락된 변수로 인해 모드 정보를 가져오지 못했습니다. 문제가 발생할 수 있습니다</system:String>
+
+    <system:String x:Key="TheFollowingModsWereNotFoundInstalledAndHaveBeenRemoved">다음 모드가 설치되어 있지 않아 프로필에서 제거되었습니다</system:String>
+    <system:String x:Key="ErrorLoadingSettingsPleaseConfigure7H">설정 불러오기 오류 - 설정 > 일반 설정... 메뉴에서 7H를 구성하세요</system:String>
+    <system:String x:Key="ErrorLoadingLibraryFile">라이브러리 파일 불러오기 오류</system:String>
+    <system:String x:Key="FailedToImportMod">모드 가져오기 실패</system:String>
+    <system:String x:Key="AutoImportedMod">모드 자동 가져오기됨</system:String>
+    <system:String x:Key="CouldNotImportIroFileIsCorrupt">파일이 손상되어 .iro 모드를 가져올 수 없습니다</system:String>
+    <system:String x:Key="ModCouldNotBeFoundHasItBeenDeleted">모드를 찾을 수 없습니다. 삭제되었나요? 목록에서 제거되었습니다.</system:String>
+
+    <system:String x:Key="CouldNotLoadProfile">프로필을 불러올 수 없습니다</system:String>
+
+    <system:String x:Key="FailedToPackIntoIro">.iro로 패킹 실패</system:String>
+    <system:String x:Key="PackingIntoIro">{0}을(를) .iro로 패킹 중 ...</system:String>
+    <system:String x:Key="UnpackingIroIntoSubfolder">{0}.iro를 하위 폴더 '{0}'로 압축 해제 중 ...</system:String>
+    <system:String x:Key="FailedToUnpackIro">.iro 압축 해제 실패</system:String>
+
+    <system:String x:Key="SelectModToDownloadFirst">먼저 다운로드할 모드를 선택하세요.</system:String>
+    <system:String x:Key="NoDownloadSelected">선택된 다운로드가 없습니다.</system:String>
+    <system:String x:Key="SelectAModFirst">먼저 모드를 선택하세요.</system:String>
+
+    <system:String x:Key="FailedToSaveCatalogXml">카탈로그 xml 저장 실패</system:String>
+
+    <system:String x:Key="ModNotActiveOnlyActivatedModsCanBeConfigured">모드가 활성화되어 있지 않습니다. 활성화된 모드만 설정할 수 있습니다.</system:String>
+
+    <system:String x:Key="UninstallWarning">제거 경고</system:String>
+    <system:String x:Key="AreYouSureYouWantToDelete">정말 삭제하시겠습니까?</system:String>
+
+
+    <!--ThemeSettingsWindow Strings-->
+    <system:String x:Key="ColorTheme">색상 테마:</system:String>
+    <system:String x:Key="AppBackground">앱 배경:</system:String>
+    <system:String x:Key="SecondaryBackground">보조 배경:</system:String>
+    <system:String x:Key="ControlsDisabledBackground">비활성화된 컨트롤 배경:</system:String>
+    <system:String x:Key="ControlsDisabledForeground">비활성화된 컨트롤 전경:</system:String>
+    <system:String x:Key="BackgroundImage">배경 이미지:</system:String>
+    <system:String x:Key="BackgroundHorizontalAlignment">배경 가로 정렬:</system:String>
+    <system:String x:Key="BackgroundVerticalAlignment">배경 세로 정렬:</system:String>
+    <system:String x:Key="BackgroundStretch">배경 늘이기:</system:String>
+    <system:String x:Key="ControlsBackground">컨트롤 배경:</system:String>
+    <system:String x:Key="ControlsForeground">컨트롤 전경:</system:String>
+    <system:String x:Key="ControlsSecondary">컨트롤 보조 텍스트:</system:String>
+    <system:String x:Key="ControlsMouseOver">컨트롤 마우스 오버:</system:String>
+    <system:String x:Key="ControlsPressed">컨트롤 눌림:</system:String>
+    <system:String x:Key="ImportTheme">테마 가져오기</system:String>
+
+
+    <!--PackIroUserControl Strings-->
+    <system:String x:Key="SourceFolder">소스 폴더:</system:String>
+    <system:String x:Key="SaveAsIro">IRO로 저장:</system:String>
+    <system:String x:Key="SaveAsIrop">IROP로 저장:</system:String>
+    <system:String x:Key="Compress">압축:</system:String>
+    <system:String x:Key="FilesToDelete">삭제할 파일:</system:String>
+    <system:String x:Key="NewIro">새 IRO:</system:String>
+    <system:String x:Key="OriginalIro">원본 IRO:</system:String>
+    <system:String x:Key="SourceIro">소스 IRO:</system:String>
+
+    <!--CreateModUserControl Strings-->
+    <system:String x:Key="OutputsCurrentModXmlToBelow">현재 mod.xml을 아래 텍스트 영역에 출력합니다.</system:String>
+    <system:String x:Key="SaveModXmlToFile">mod.xml을 파일로 저장</system:String>
+    <system:String x:Key="LoadModXmlFileToEdit">편집할 mod.xml 파일 불러오기</system:String>
+
+    <system:String x:Key="GeneralSettingsTitle">일반 설정</system:String>
+
+    <system:String x:Key="Greek">그리스어</system:String>
+
+    <system:String x:Key="ModSettingNoCompatibleOptionFoundTheFollowingModsRestrictIt">모드 {0}, 설정 {1} - 호환 가능한 옵션을 찾을 수 없습니다. 다음 모드들이 모두 설정 방법을 제한합니다:\n\n{2}</system:String>
+    <system:String x:Key="ModChangedSettingTo">모드 {0} - 설정 {1}을(를) {2}(으)로 변경했습니다</system:String>
+
+    <system:String x:Key="OutputsCurrentCatalogXmlToBelow">현재 catalog.xml을 아래 텍스트 영역에 출력합니다.</system:String>
+    <system:String x:Key="SaveCatalogXmlToFile">catalog.xml을 파일로 저장</system:String>
+    <system:String x:Key="LoadCatalogXmlFileToEdit">편집할 catalog.xml 파일 불러오기</system:String>
+    <system:String x:Key="AddModToCatalog">카탈로그에 모드 추가</system:String>
+    <system:String x:Key="ImportModFromModXmlOrIro">mod.xml 또는 .iro에서 모드 가져오기</system:String>
+    <system:String x:Key="CatalogName">카탈로그 이름:</system:String>
+    <system:String x:Key="SaveCatalogXml">카탈로그 .xml 저장</system:String>
+    <system:String x:Key="SelectCatalogXmlToLoad">불러올 catalog.xml 선택</system:String>
+    <system:String x:Key="SelectModXmlOrIroFileToLoad">불러올 mod.xml 또는 .iro 파일 선택</system:String>
+    <system:String x:Key="SelectImageToUse">사용할 이미지 선택</system:String>
+    <system:String x:Key="SaveModXml">mod .xml 저장</system:String>
+    <system:String x:Key="SelectModXmlToLoad">불러올 mod.xml 선택</system:String>
+
+    <system:String x:Key="SaveAsIroTitle">.iro로 저장</system:String>
+    <system:String x:Key="SaveAsIropTitle">.irop으로 저장</system:String>
+
+    <system:String x:Key="SelectTheFolderThatContainsAllTheModFiles">IRO 아카이브로 패킹할 모든 모드 파일이 들어 있는 폴더를 선택하세요.</system:String>
+    <system:String x:Key="SelectFolderToOutputUnpackedFiles">압축 해제된 파일을 출력할 폴더를 선택하세요.</system:String>
+
+    <system:String x:Key="SelectFLevelLgpFile">FLevel.lgp 파일 선택</system:String>
+
+    <system:String x:Key="GameLauncherSettings">게임 런처 설정</system:String>
+
+    <system:String x:Key="ClickToSelectFf7ExeFile">FF7.exe 파일을 선택하려면 클릭하세요</system:String>
+    <system:String x:Key="ClickToSelectWhereYourMovieFolderIs">동영상 폴더 위치를 선택하려면 클릭하세요</system:String>
+    <system:String x:Key="ClickToSelectWhereTexturesAreStored">텍스처 저장 위치를 선택하려면 클릭하세요</system:String>
+    <system:String x:Key="ClickToSelectWhereYourModLibraryIs">모드 라이브러리 위치를 선택하려면 클릭하세요</system:String>
+
+    <system:String x:Key="FF7ExeLabel">FF7 실행 파일:</system:String>
+    <system:String x:Key="MoviesLabel">동영상:</system:String>
+    <system:String x:Key="TexturesLabel">텍스처:</system:String>
+    <system:String x:Key="LibraryLabel">라이브러리:</system:String>
+
+    <system:String x:Key="AddSubscriptionURL">구독 URL 추가</system:String>
+    <system:String x:Key="RemoveSubscriptionURL">구독 URL 제거</system:String>
+    <system:String x:Key="EditSubscriptionURL">구독 URL/이름 편집</system:String>
+    <system:String x:Key="MoveSubscriptionUp">구독 위로 이동. 우클릭하여 맨 위로 이동.</system:String>
+    <system:String x:Key="MoveSubscriptionDown">구독 아래로 이동. 우클릭하여 맨 아래로 이동</system:String>
+
+    <system:String x:Key="AddFolder">폴더 추가</system:String>
+    <system:String x:Key="RemoveFolder">폴더 제거</system:String>
+    <system:String x:Key="MoveFolderUp">폴더 위로 이동. 우클릭하여 맨 위로 이동.</system:String>
+    <system:String x:Key="MoveFolderDown">폴더 아래로 이동. 우클릭하여 맨 아래로 이동.</system:String>
+    <system:String x:Key="EnterUrlInIrosFormat">iros:// 형식으로 URL을 입력하세요</system:String>
+
+    <system:String x:Key="SelectCustomThemeXmlFile">사용자 정의 테마 .xml 파일 선택</system:String>
+    <system:String x:Key="SaveCustomThemeXmlFile">사용자 정의 테마 .xml 파일 저장</system:String>
+
+    <!--App Hints Strings-->
+    <system:String x:Key="AppHint1">모드를 드래그 앤 드롭하여 목록 순서를 변경할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint2">모드를 가운데 클릭하여 활성화 또는 비활성화할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint3">모드를 더블클릭하여 모드 설정 창을 열 수 있습니다.</system:String>
+    <system:String x:Key="AppHint4">카탈로그 탐색에서 모드를 더블클릭하여 다운로드를 시작할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint5">자동 정렬 버튼을 클릭하여 모드 목록을 권장 순서로 빠르게 정렬할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint6">모드는 이제 자동으로 자신을 업데이트하거나 새 버전을 알릴 수 있습니다.</system:String>
+    <system:String x:Key="AppHint7">모드 제작자: Readme.html에 이미지를 base64로 인코딩할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint8">모드 제작자: mod.xml에서 OrderConstraints를 사용하여 로드 순서를 지정할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint9">모드 제작자: 7th Heaven은 이제 모드 설정 옵션에 트리뷰 스타일을 지원합니다.</system:String>
+    <system:String x:Key="AppHint10">모드 제작자: 7th Heaven은 이제 카탈로그에서 iros://ExternalURL을 지원하여 웹 브라우저에서 다운로드를 열 수 있습니다.</system:String>
+    <system:String x:Key="AppHint11">모드 제작자: 일반 설정/탐색기에서 컨텍스트 메뉴를 활성화하여 Windows에서 마우스 우클릭 모드 옵션을 사용할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint12">모드 제작자: 카탈로그 다운로드를 위해 IRO를 .7z/RAR/zip으로 압축할 수 있으며 7H가 자동으로 압축을 해제합니다.</system:String>
+    <system:String x:Key="AppHint13">모드 제작자: 호환성을 위해 다른 모드의 설정을 프로그래밍 방식으로 변경할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint14">Windows에서 모드 파일을 더블클릭하여 7th Heaven으로 열거나 가져올 수 있습니다.</system:String>
+    <system:String x:Key="AppHint15">프로필 관리 창에서 프로필을 더블클릭하여 선택한 프로필을 불러올 수 있습니다.</system:String>
+    <system:String x:Key="AppHint16">프로필 세부 정보는 이제 설정 > 프로필에서 눈 모양 아이콘을 클릭하여 확인할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint17">7th Heaven은 모드를 비활성화했다가 다시 활성화해도 이전 설정 모드 설정을 기억합니다.</system:String>
+    <system:String x:Key="AppHint18">설정 모드 창에서 '모드 기본값으로 초기화'를 클릭하여 모드 설정을 초기화할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint19">카탈로그 구독을 실수로 삭제했나요? 일반 설정에서 '기본값으로 초기화'를 클릭하세요.</system:String>
+    <system:String x:Key="AppHint20">내 모드 탭을 우클릭하여 Windows에서 모드 라이브러리 폴더를 열 수 있습니다.</system:String>
+    <system:String x:Key="AppHint21">카탈로그 탐색 탭을 우클릭하여 카탈로그 설정을 열 수 있습니다.</system:String>
+    <system:String x:Key="AppHint22">사이드바의 화살표를 우클릭하여 모드를 맨 위 또는 맨 아래로 보낼 수 있습니다.</system:String>
+    <system:String x:Key="AppHint23">열 보기가 엉망이 되었나요? 사이드바의 '열 초기화' 버튼을 클릭하세요.</system:String>
+    <system:String x:Key="AppHint24">내 모드의 카테고리 열에서 화살표를 클릭하여 이전 모드의 '알 수 없음' 카테고리를 수정할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint25">많은 질문이나 문제에 대한 답변을 https://forums.qhimm.com 포럼에서 찾을 수 있습니다.</system:String>
+    <system:String x:Key="AppHint26">도움말 메뉴에서 많은 질문이나 문제에 대한 답변을 찾을 수 있습니다.</system:String>
+    <system:String x:Key="AppHint27">설정 > 게임 드라이버...를 통해 게임의 그래픽 설정을 변경할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint28">모드 정보 패널의 드롭다운 화살표에서 각 모드의 업데이트 설정을 변경하세요.</system:String>
+    <system:String x:Key="AppHint29">7th Heaven이 자동으로 가상 게임 디스크를 마운트하고 마운트 해제합니다.</system:String>
+    <system:String x:Key="AppHint30">7th Heaven은 더 이상 이전 게임 컨버터가 필요하지 않습니다. 이제 모든 것이 자동으로 처리됩니다!</system:String>
+    <system:String x:Key="AppHint31">더 이상 FF7Config.exe를 사용할 필요가 없습니다. 해당 기능이 설정 > 게임 런처에 내장되어 있습니다.</system:String>
+    <system:String x:Key="AppHint32">7th Heaven 1.0이 2013년에 출시된 것을 알고 계셨나요? 2.0은 7년 후인 2020년에 출시되었습니다.</system:String>
+    <system:String x:Key="AppHint33">현재 활성 프로필이 대괄호 안에 제목 표시줄에 표시됩니다.</system:String>
+    <system:String x:Key="AppHint34">고DPI 지원이 이제 게임 드라이버에 내장되어 있습니다.</system:String>
+    <system:String x:Key="AppHint35">열 머리글을 클릭하여 카탈로그 탐색 열을 정렬할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint36">열 머리글을 드래그 앤 드롭하여 열을 재배열할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint37">검색 창 옆의 드롭다운 화살표를 클릭하여 보기를 필터링할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint38">'설정 > 컨트롤'에서 키보드/게임패드 컨트롤 옵션을 빠르게 전환하세요.</system:String>
+    <system:String x:Key="AppHint39">알고 계셨나요? 7th Heaven은 명령줄 매개변수(스위치)를 지원합니다.</system:String>
+    <system:String x:Key="AppHint40">1998년 디스크를 갖고 계신가요? '동영상 가져오기'에서 동영상을 자동으로 가져오세요.</system:String>
+    <system:String x:Key="AppHint41">설정 > 색상 테마 변경을 통해 7th Heaven 색상을 사용자 정의할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint42">사용자 정의 색상 테마를 내보내어 다른 사람들과 공유할 수 있습니다.</system:String>
+    <system:String x:Key="AppHint43">일부 다운로드를 일시 중지하고 재개할 수 있습니다.</system:String>
+
+    <system:String x:Key="ModManagerForFinalFantasy7">Final Fantasy 7 모드 매니저 ( Tsunamods 팀이 관리합니다 )</system:String>
+
+    <system:String x:Key="ReleaseDateLabel">출시일:</system:String>
+    <system:String x:Key="ImageLinkLabel">이미지 링크:</system:String>
+    <system:String x:Key="InfoLinkLabel">정보 링크:</system:String>
+    <system:String x:Key="DownloadLinksHeader" xml:space="preserve"> 다운로드 링크 </system:String>
+    <system:String x:Key="AddLink">링크 추가</system:String>
+
+    <system:String x:Key="MegaFolderID">Mega 폴더 ID:</system:String>
+
+    <system:String x:Key="Miscellaneous">기타</system:String>
+    <system:String x:Key="Animations">애니메이션</system:String>
+    <system:String x:Key="BattleModels">전투 모델</system:String>
+    <system:String x:Key="BattleTextures">전투 텍스처</system:String>
+    <system:String x:Key="FieldModels">필드 모델</system:String>
+    <system:String x:Key="FieldTextures">필드 텍스처</system:String>
+    <system:String x:Key="Gameplay">게임플레이</system:String>
+    <system:String x:Key="Media">미디어</system:String>
+    <system:String x:Key="Minigames">미니게임</system:String>
+    <system:String x:Key="SpellTextures">마법 텍스처</system:String>
+    <system:String x:Key="UserInterface">사용자 인터페이스</system:String>
+    <system:String x:Key="WorldModels">월드 모델</system:String>
+    <system:String x:Key="WorldTextures">월드 텍스처</system:String>
+    <system:String x:Key="ModShaders">셰이더</system:String>
+
+    <system:String x:Key="Cancelling">취소 중</system:String>
+
+    <system:String x:Key="Volume">볼륨</system:String>
+
+    <system:String x:Key="BrazilianPortuguese">브라질 포르투갈어</system:String>
+
+    <system:String x:Key="Italian">이탈리아어</system:String>
+
+    <system:String x:Key="SetInGameControls">게임 내 컨트롤 설정</system:String>
+    <system:String x:Key="Keyboard">키보드</system:String>
+    <system:String x:Key="Controller">컨트롤러</system:String>
+    <system:String x:Key="ConfirmLabel">[확인]</system:String>
+    <system:String x:Key="CancelLabel">[취소]</system:String>
+    <system:String x:Key="MenuLabel">[메뉴]</system:String>
+    <system:String x:Key="SwitchLabel">[전환]</system:String>
+    <system:String x:Key="ScrollUpLabel">[위로 스크롤]</system:String>
+    <system:String x:Key="ScrollDownLabel">[아래로 스크롤]</system:String>
+
+    <system:String x:Key="CameraLabel">[카메라]</system:String>
+    <system:String x:Key="TargetLabel">[타겟]</system:String>
+    <system:String x:Key="AssistLabel">[보조]</system:String>
+    <system:String x:Key="StartLabel">[시작]</system:String>
+
+    <system:String x:Key="UpLabel">[위]</system:String>
+    <system:String x:Key="DownLabel">[아래]</system:String>
+    <system:String x:Key="LeftLabel">[왼쪽]</system:String>
+    <system:String x:Key="RightLabel">[오른쪽]</system:String>
+
+    <system:String x:Key="Presets">프리셋:</system:String>
+    <system:String x:Key="EnablePS4ControllerSupport">PS4 XInput 드라이버 활성화</system:String>
+    <system:String x:Key="PS4ControllerSupportTooltip">PS4 컨트롤러를 XInput 장치로 사용하고 컨트롤러 터치패드로 마우스를 제어할 수 있습니다 (SCP 드라이버가 설치되어 있어야 합니다)</system:String>
+    <system:String x:Key="SaveChangesTooltip">컨트롤 변경 사항을 저장합니다.</system:String>
+
+    <system:String x:Key="OpenGameControllersWindow">게임 컨트롤러 창 열기</system:String>
+
+    <system:String x:Key="ControlsTooltip">게임 내 키보드 및 게임패드 컨트롤을 설정합니다. 저장 아이콘을 클릭하여 위의 컨트롤 매핑을 사용자 정의 설정으로 저장하세요.</system:String>
+
+    <system:String x:Key="StartingPS4ControllerService">PS4 컨트롤러 서비스 시작 중 ...</system:String>
+    <system:String x:Key="ServiceAlreadyRunning">서비스가 이미 실행 중 ...</system:String>
+
+    <system:String x:Key="RetryInstallTooltip">모드 설치 다시 시도</system:String>
+
+    <system:String x:Key="MovieImporter">동영상 가져오기...</system:String>
+    <system:String x:Key="AllMovieFilesAlreadyImported" xml:space="preserve">모든 동영상이 이미 가져와졌습니다!</system:String>
+
+    <system:String x:Key="ImportMoviesFromDisc">디스크에서 동영상 가져오기</system:String>
+
+    <system:String x:Key="EnableTriggerDpadSupport">DInput 장치에서 방향패드 에뮬레이션</system:String>
+    <system:String x:Key="TriggerDpadSupportTooltip">해당 키보드 키를 전송하여 게임 내 방향패드를 에뮬레이션합니다. (XInput 컨트롤러를 사용하는 경우 비활성화하세요)</system:String>
+
+    <system:String x:Key="MountDiscWithPowershell">PowerShell로 디스크 마운트</system:String>
+    <system:String x:Key="MountDiscWithWinCDEmu">WinCDEmu로 디스크 마운트</system:String>
+    <system:String x:Key="DoNotMount">디스크 자동 마운트 안 함</system:String>
+
+    <system:String x:Key="LoadingDevices">장치 불러오는 중 ...</system:String>
+
+    <system:String x:Key="MountOptionToolTip">가상 FF7DISC1 게임 디스크 마운트 방법을 선택하세요. Windows 7은 'WinCDEmu로 디스크 마운트' 옵션만 사용할 수 있습니다.</system:String>
+
+    <system:String x:Key="ControlsMenuItemText">컨트롤...</system:String>
+
+    <system:String x:Key="SaveControlsPreset">현재 컨트롤을 새 설정으로 저장해야 합니다. 설정 이름을 입력하세요:</system:String>
+
+    <system:String x:Key="VerifyingEnglishGameFilesExist">영어 게임 파일이 있는지 확인 중 ...</system:String>
+    <system:String x:Key="FoundLanguageInstalledCreatingEnglishGameFiles">설치된 언어를 찾았습니다: {0} 영어 게임 파일 생성 중...</system:String>
+    <system:String x:Key="ErrorOnlyEnglishLanguageSupported">오류: 영어 언어만 지원됩니다. Steam에서 FF7을 영어(미국)로 설치하는 것을 고려하세요.</system:String>
+    <system:String x:Key="ExtractingLGPFiles">.lgp 파일 추출 중 ...</system:String>
+    <system:String x:Key="RenamingLanguageSpecificFiles">언어별 파일 이름 변경 중 ...</system:String>
+    <system:String x:Key="CouldNotFindFileToRename">이름을 변경할 파일을 찾을 수 없습니다: {0} ...</system:String>
+    <system:String x:Key="EncodingNewLGPFiles">새 .lgp 파일 인코딩 중 ...</system:String>
+    <system:String x:Key="DeletingTemporaryFiles">임시 파일 삭제 중 ...</system:String>
+    <system:String x:Key="BeginningToPollForGamePadInput">게임패드 입력 폴링 시작 중 ...</system:String>
+    <system:String x:Key="WaitingForFF7WindowToBeVisible">FF7 창이 표시되기를 대기 중 (최대 {0}초) ...</system:String>
+    <system:String x:Key="CouldNotFindFileToCopy">복사할 파일을 찾을 수 없습니다: {0} ...</system:String>
+    <system:String x:Key="AnErrorOccurredStartingULGP">ulgp.exe 시작 중 오류가 발생했습니다</system:String>
+    <system:String x:Key="UpdatingPathsInSysSettings">새 설치 경로로 Sys.Settings의 경로 업데이트 중</system:String>
+    <system:String x:Key="ForceMinimizingProgram">프로그램 강제 최소화 중 ...</system:String>
+    <system:String x:Key="FailedToStartAdditionalProgram">추가 프로그램 시작 실패: {0}</system:String>
+
+    <system:String x:Key="CanaryWarningTitle">반드시 읽어주세요!</system:String>
+    <system:String x:Key="CanaryWarningMessage">카나리 채널로 전환해 주셔서 감사합니다.\n\n이 채널은 개발을 지원하고 버그를 보고할 의향이 있는 고급 사용자에게만 권장됩니다. 안정적인 게임 경험을 원한다면 이 채널을 사용하지 마세요.\n\n크래시가 발생할 수 있으며 누구도 테스트하지 않습니다. 이 빌드는 본인 책임하에 사용하세요!</system:String>
+
+    <system:String x:Key="PleaseUpdateFFNx">FFNx.toml 파일에서 설정을 불러올 수 없습니다. 현재 FFNx 버전이 오래된 것 같습니다. 선택한 채널에 맞는 최신 버전의 FFNx로 업데이트하고 다시 시도해 보세요.</system:String>
+
+    <system:String x:Key="CheckForSystemDEPStatus">시스템 DEP 상태 확인 중...</system:String>
+    <system:String x:Key="DEPDetected">DEP 감지됨</system:String>
+    <system:String x:Key="DoYouWantToDisableDEP">DEP가 현재 서버 환경으로 설정되어 있거나 전혀 활성화되어 있지 않습니다. 데스크톱 모드로 변경하시겠습니까?</system:String>
+    <system:String x:Key="SystemDEPDisabledPleaseReboot">DEP 모드가 성공적으로 업데이트되었습니다. 변경 사항을 적용하려면 PC를 재부팅하세요.</system:String>
+    <system:String x:Key="CannotContinueWithDEPEnabled">DEP 모드가 올바르지 않습니다. 계속하려면 조정해 주세요: https://7thheaven.rocks/help/dep.html</system:String>
+    <system:String x:Key="SomethingWentWrongWhileDisablingDEP">DEP 조정 중 문제가 발생했습니다. 수동으로 조정해 주세요: https://7thheaven.rocks/help/dep.html</system:String>
+
+    <system:String x:Key="App4GBPatchRequired">게임 exe에 4GB 패치가 적용되어 있는지 확인 중...</system:String>
+    <system:String x:Key="App4GBPatchApplied">4GB 패치가 성공적으로 적용되었습니다.</system:String>
+
+    <system:String x:Key="OpenSaveGamePath">저장 파일 디렉토리 열기...</system:String>
+</ResourceDictionary>

--- a/AppUI/Resources/Languages/StringResources.zh.xaml
+++ b/AppUI/Resources/Languages/StringResources.zh.xaml
@@ -724,6 +724,7 @@
     <system:String x:Key="Spanish">西班牙语</system:String>
     <system:String x:Key="Japanese">日语</system:String>
     <system:String x:Key="SimplifiedChinese">简体中文</system:String>
+    <system:String x:Key="Korean">韩语</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/Resources/StringResources.xaml
+++ b/AppUI/Resources/StringResources.xaml
@@ -726,6 +726,7 @@ Click 'Cancel' to stop the process.</system:String>
     <system:String x:Key="Spanish">Spanish</system:String>
     <system:String x:Key="Japanese">Japanese</system:String>
     <system:String x:Key="SimplifiedChinese">Simplified Chinese</system:String>
+    <system:String x:Key="Korean">Korean</system:String>
 
 
     <!--GameLauncher Strings-->

--- a/AppUI/ViewModels/SetLanguageViewModel.cs
+++ b/AppUI/ViewModels/SetLanguageViewModel.cs
@@ -63,6 +63,7 @@ namespace AppUI.ViewModels
             LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Italian)} (Italiano)", "it");
             LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Spanish)} (Español)", "es");
             LanguagesMap.Add($"{ResourceHelper.Get(StringKey.SimplifiedChinese)} (\u4e2d\u6587\u7b80\u4f53)", "zh");
+            LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Korean)} (\ud55c\uad6d\uc5b4)", "ko");
             //LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Japanese)} (\u65e5\u672c\u8a9e)", "ja");
 
 


### PR DESCRIPTION
## Summary

- Adds `StringResources.ko.xaml` with full Korean translations (1262 lines)
- Adds `7H_GameDriver_UI.ko.xml` with Korean game driver UI strings (369 lines)
- Registers Korean as a selectable language in `SetLanguageViewModel`

## Test plan

- [ ] Launch 7th Heaven and switch language to Korean in General Settings
- [ ] Verify UI strings display correctly in Korean
- [ ] Verify game driver UI strings display correctly in Korean