### PR TITLE
AppUI: modernize lazy-init getters to use ??= (C# 8)

### DIFF
--- a/AppUI/ViewModels/CatalogViewModel.cs
+++ b/AppUI/ViewModels/CatalogViewModel.cs
@@ -63,16 +63,7 @@ namespace AppUI.ViewModels
         /// </summary>
         public List<CatalogModItemViewModel> CatalogModList
         {
-            get
-            {
-                // guarantee the property never returns null
-                if (_catalogModList == null)
-                {
-                    _catalogModList = new List<CatalogModItemViewModel>();
-                }
-
-                return _catalogModList;
-            }
+            get => _catalogModList ??= new List<CatalogModItemViewModel>();
             set
             {
                 _catalogModList = value;
@@ -82,16 +73,7 @@ namespace AppUI.ViewModels
 
         public ObservableCollection<DownloadItemViewModel> DownloadList
         {
-            get
-            {
-                // guarantee the property never returns null
-                if (_downloadList == null)
-                {
-                    _downloadList = new ObservableCollection<DownloadItemViewModel>();
-                }
-
-                return _downloadList;
-            }
+            get => _downloadList ??= new ObservableCollection<DownloadItemViewModel>();
             set
             {
                 _downloadList = value;

--- a/AppUI/ViewModels/MyModsViewModel.cs
+++ b/AppUI/ViewModels/MyModsViewModel.cs
@@ -41,16 +41,7 @@ namespace AppUI.ViewModels
         /// </summary>
         public ObservableCollection<InstalledModViewModel> ModList
         {
-            get
-            {
-                // guarantee the property never returns null
-                if (_modList == null)
-                {
-                    _modList = new ObservableCollection<InstalledModViewModel>();
-                }
-
-                return _modList;
-            }
+            get => _modList ??= new ObservableCollection<InstalledModViewModel>();
             set
             {
                 _modList = value;


### PR DESCRIPTION
## Summary

- Replaces 3 verbose null-check lazy-init patterns with the `??=` null-coalescing assignment operator introduced in C# 8
- Affected properties: `CatalogViewModel.CatalogModList`, `CatalogViewModel.DownloadList`, `MyModsViewModel.ModList`
- No behavior change — semantics are identical

## Test plan

- [ ] Build solution and verify no compile errors
- [ ] Launch app and confirm Catalog and My Mods tabs load without errors
- [ ] Verify download list and mod list populate correctly